### PR TITLE
FindWindowA

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2822,6 +2822,12 @@ extern "system" {
         lprc: *const RECT,
         hbr: HBRUSH,
     ) -> c_int;
+    /// Retrieves a handle to the top-level window whose class name and window name match the specified strings.
+    /// cf. http://msdn.microsoft.com/library/windows/desktop/ms633499%28v=vs.85%29.aspx
+    pub fn FindWindowA (
+        lpClassName: LPCSTR,
+        lpWindowName: LPCSTR
+    ) -> HWND;
     pub fn GetClientRect(
         hWnd: HWND,
         lpRect: LPRECT,


### PR DESCRIPTION
Function to find a window's handle by its title.
BTW, with `SW_HIDE` this is sometimes useful as a workaround for the lack of `-mwindows` in Cargo (https://github.com/rust-lang/cargo/issues/544).
