### PR TITLE
Registry API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,6 +339,8 @@ pub type PCNZCH = *const CHAR;
 // Skipping TCHAR things
 pub type PSHORT = *mut SHORT;
 pub type PLONG = *mut LONG;
+pub type ACCESS_MASK = DWORD;
+pub type PACCESS_MASK = *mut ACCESS_MASK;
 #[repr(C)]
 #[deriving(Copy)]
 pub struct PROCESSOR_NUMBER {
@@ -538,6 +540,99 @@ pub const PROCESS_SUSPEND_RESUME: DWORD = 0x0800;
 pub const PROCESS_QUERY_LIMITED_INFORMATION: DWORD = 0x1000;
 pub const PROCESS_SET_LIMITED_INFORMATION: DWORD = 0x2000;
 pub const PROCESS_ALL_ACCESS: DWORD = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0xFFFF;
+
+pub const TOKEN_ASSIGN_PRIMARY: DWORD = 0x0001;
+pub const TOKEN_DUPLICATE: DWORD = 0x0002;
+pub const TOKEN_IMPERSONATE: DWORD = 0x0004;
+pub const TOKEN_QUERY: DWORD = 0x0008;
+pub const TOKEN_QUERY_SOURCE: DWORD = 0x0010;
+pub const TOKEN_ADJUST_PRIVILEGES: DWORD = 0x0020;
+pub const TOKEN_ADJUST_GROUPS: DWORD = 0x0040;
+pub const TOKEN_ADJUST_DEFAULT: DWORD = 0x0080;
+pub const TOKEN_ADJUST_SESSIONID: DWORD = 0x0100;
+
+pub const TOKEN_ALL_ACCESS_P: DWORD = STANDARD_RIGHTS_REQUIRED |
+    TOKEN_ASSIGN_PRIMARY |
+    TOKEN_DUPLICATE |
+    TOKEN_IMPERSONATE |
+    TOKEN_QUERY |
+    TOKEN_QUERY_SOURCE |
+    TOKEN_ADJUST_PRIVILEGES |
+    TOKEN_ADJUST_GROUPS |
+    TOKEN_ADJUST_DEFAULT;
+pub const TOKEN_ALL_ACCESS: DWORD = TOKEN_ALL_ACCESS_P | TOKEN_ADJUST_SESSIONID;
+pub const TOKEN_READ: DWORD = STANDARD_RIGHTS_READ | TOKEN_QUERY;
+pub const TOKEN_WRITE: DWORD = STANDARD_RIGHTS_WRITE |
+    TOKEN_ADJUST_PRIVILEGES |
+    TOKEN_ADJUST_GROUPS |
+    TOKEN_ADJUST_DEFAULT;
+pub const TOKEN_EXECUTE: DWORD = STANDARD_RIGHTS_EXECUTE;
+
+pub const KEY_QUERY_VALUE: REGSAM = 0x0001;
+pub const KEY_SET_VALUE: REGSAM = 0x0002;
+pub const KEY_CREATE_SUB_KEY: REGSAM = 0x0004;
+pub const KEY_ENUMERATE_SUB_KEYS: REGSAM = 0x0008;
+pub const KEY_NOTIFY: REGSAM = 0x0010;
+pub const KEY_CREATE_LINK: REGSAM = 0x0020;
+pub const KEY_WOW64_32KEY: REGSAM = 0x0200;
+pub const KEY_WOW64_64KEY: REGSAM = 0x0100;
+pub const KEY_WOW64_RES: REGSAM = 0x0300;
+
+pub const KEY_READ: REGSAM = (
+        STANDARD_RIGHTS_READ |
+        KEY_QUERY_VALUE |
+        KEY_ENUMERATE_SUB_KEYS |
+        KEY_NOTIFY
+    ) & (!SYNCHRONIZE);
+pub const KEY_WRITE: REGSAM = (STANDARD_RIGHTS_WRITE | KEY_SET_VALUE | KEY_CREATE_SUB_KEY) & (!SYNCHRONIZE);
+pub const KEY_EXECUTE: REGSAM = KEY_READ & (!SYNCHRONIZE);
+pub const KEY_ALL_ACCESS: REGSAM = (
+        STANDARD_RIGHTS_ALL |
+        KEY_QUERY_VALUE |
+        KEY_SET_VALUE |
+        KEY_CREATE_SUB_KEY |
+        KEY_ENUMERATE_SUB_KEYS |
+        KEY_NOTIFY |
+        KEY_CREATE_LINK
+    ) & (!SYNCHRONIZE);
+
+pub const REG_CREATED_NEW_KEY: DWORD = 0x00000001;
+pub const REG_OPENED_EXISTING_KEY: DWORD = 0x00000002;
+
+pub const REG_NOTIFY_CHANGE_NAME: DWORD = 0x00000001;
+pub const REG_NOTIFY_CHANGE_ATTRIBUTES: DWORD = 0x00000002;
+pub const REG_NOTIFY_CHANGE_LAST_SET: DWORD = 0x00000004;
+pub const REG_NOTIFY_CHANGE_SECURITY: DWORD = 0x00000008;
+
+pub const REG_LEGAL_CHANGE_FILTER: DWORD = REG_NOTIFY_CHANGE_NAME |
+    REG_NOTIFY_CHANGE_ATTRIBUTES |
+    REG_NOTIFY_CHANGE_LAST_SET |
+    REG_NOTIFY_CHANGE_SECURITY;
+
+pub const REG_NOTIFY_THREAD_AGNOSTIC: DWORD = 0x10000000; //supported only on Windows 8 and later
+
+pub const REG_OPTION_RESERVED: DWORD = 0x00000000;
+pub const REG_OPTION_NON_VOLATILE: DWORD = 0x00000000;
+pub const REG_OPTION_VOLATILE: DWORD = 0x00000001;
+pub const REG_OPTION_CREATE_LINK: DWORD = 0x00000002;
+pub const REG_OPTION_BACKUP_RESTORE: DWORD = 0x00000004;
+pub const REG_OPTION_OPEN_LINK: DWORD = 0x00000008;
+
+pub const REG_NONE: DWORD = 0;
+pub const REG_SZ: DWORD = 1;
+pub const REG_EXPAND_SZ: DWORD = 2;
+pub const REG_BINARY: DWORD = 3;
+pub const REG_DWORD: DWORD = 4;
+pub const REG_DWORD_LITTLE_ENDIAN: DWORD = 4;
+pub const REG_DWORD_BIG_ENDIAN: DWORD = 5;
+pub const REG_LINK: DWORD = 6;
+pub const REG_MULTI_SZ: DWORD = 7;
+pub const REG_RESOURCE_LIST: DWORD = 8;
+pub const REG_FULL_RESOURCE_DESCRIPTOR: DWORD = 9;
+pub const REG_RESOURCE_REQUIREMENTS_LIST: DWORD = 10;
+pub const REG_QWORD: DWORD = 11;
+pub const REG_QWORD_LITTLE_ENDIAN: DWORD = 11;
+
 // guiddef.h
 #[repr(C)]
 #[deriving(Copy)]
@@ -2116,6 +2211,61 @@ pub struct PROCESS_MEMORY_COUNTERS_EX {
 }
 
 //-------------------------------------------------------------------------------------------------
+// winreg.h
+// Registry API procedure declarations, constant definitions and macros
+//-------------------------------------------------------------------------------------------------
+
+pub type REGSAM = ACCESS_MASK;
+
+#[repr(C)]
+#[deriving(Copy)]
+pub struct VALENTA {
+    pub ve_valuename: LPSTR,
+    pub ve_valuelen: DWORD,
+    pub ve_valueptr: DWORD_PTR,
+    pub ve_type: DWORD,
+}
+pub type PVALENTA = *mut VALENTA;
+
+#[repr(C)]
+#[deriving(Copy)]
+pub struct VALENTW {
+    pub ve_valuename: LPWSTR,
+    pub ve_valuelen: DWORD,
+    pub ve_valueptr: DWORD_PTR,
+    pub ve_type: DWORD,
+}
+pub type PVALENTW = *mut VALENTW;
+
+pub const HKEY_CLASSES_ROOT: HKEY = 0x80000000 as HKEY;
+pub const HKEY_CURRENT_USER: HKEY = 0x80000001 as HKEY;
+pub const HKEY_LOCAL_MACHINE: HKEY = 0x80000002 as HKEY;
+pub const HKEY_USERS: HKEY = 0x80000003 as HKEY;
+pub const HKEY_PERFORMANCE_DATA: HKEY = 0x80000004 as HKEY;
+pub const HKEY_PERFORMANCE_TEXT: HKEY = 0x80000050 as HKEY;
+pub const HKEY_PERFORMANCE_NLSTEXT: HKEY = 0x80000060 as HKEY;
+pub const HKEY_CURRENT_CONFIG: HKEY = 0x80000005 as HKEY;
+pub const HKEY_DYN_DATA: HKEY = 0x80000006 as HKEY;
+pub const HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY = 0x80000007 as HKEY;
+
+pub const REG_MUI_STRING_TRUNCATE: DWORD = 0x00000001;
+
+pub const RRF_RT_REG_NONE: DWORD = 0x00000001;
+pub const RRF_RT_REG_SZ: DWORD = 0x00000002;
+pub const RRF_RT_REG_EXPAND_SZ: DWORD = 0x00000004;
+pub const RRF_RT_REG_BINARY: DWORD = 0x00000008;
+pub const RRF_RT_REG_DWORD: DWORD = 0x00000010;
+pub const RRF_RT_REG_MULTI_SZ: DWORD = 0x00000020;
+pub const RRF_RT_REG_QWORD: DWORD = 0x00000040;
+
+pub const RRF_RT_DWORD: DWORD = RRF_RT_REG_BINARY|RRF_RT_REG_DWORD;
+pub const RRF_RT_QWORD: DWORD = RRF_RT_REG_BINARY|RRF_RT_REG_QWORD;
+pub const RRF_RT_ANY: DWORD = 0x0000ffff;
+
+pub const RRF_NOEXPAND: DWORD = 0x10000000;
+pub const RRF_ZEROONFAILURE: DWORD = 0x20000000;
+
+//-------------------------------------------------------------------------------------------------
 // winuser.h
 // USER procedure declarations, constant definitions and macros
 //-------------------------------------------------------------------------------------------------
@@ -3372,6 +3522,7 @@ extern "system" {
         hConsoleHandle: HANDLE,
         lpMode: LPDWORD,
     ) -> BOOL;
+    pub fn GetCurrentProcess() -> HANDLE;
     pub fn GetLastError() -> DWORD;
     pub fn GetModuleHandleA(
         lpModuleName: LPCSTR,
@@ -3389,6 +3540,10 @@ extern "system" {
         lpExitTime: LPFILETIME,
         lpKernelTime: LPFILETIME,
         lpUserTime: LPFILETIME,
+    ) -> BOOL;
+    pub fn GetSystemRegistryQuota(
+        pdwQuotaAllowed: PDWORD,
+        pdwQuotaUsed: PDWORD
     ) -> BOOL;
     pub fn K32GetProcessMemoryInfo(
         Process: HANDLE,
@@ -3454,6 +3609,309 @@ extern "system" {
         PreviousState: PTOKEN_PRIVILEGES,
         ReturnLength: PDWORD,
     ) -> BOOL;
+    pub fn OpenProcessToken(
+        ProcessHandle: HANDLE,
+        DesiredAccess: DWORD,
+        TokenHandle: PHANDLE
+    ) -> BOOL;
+    pub fn RegCloseKey(
+        hKey: HKEY
+    ) -> LONG;
+    pub fn RegConnectRegistryA(
+        lpMachineName: LPCSTR,
+        hKey: HKEY,
+        phkResult: PHKEY
+    ) -> LONG;
+    pub fn RegConnectRegistryW(
+        lpMachineName: LPCWSTR,
+        hKey: HKEY,
+        phkResult: PHKEY
+    ) -> LONG;
+    pub fn RegCopyTreeA(
+        hKeySrc: HKEY,
+        lpSubKey: LPCSTR,
+        hKeyDest: HKEY
+    ) -> LONG;
+    pub fn RegCopyTreeW(
+        hKeySrc: HKEY,
+        lpSubKey: LPCWSTR,
+        hKeyDest: HKEY
+    ) -> LONG;
+    pub fn RegCreateKeyExA(
+        hKey: HKEY,
+        lpSubKey: LPCSTR,
+        Reserved: DWORD,
+        lpClass: LPCSTR,
+        dwOptions: DWORD,
+        samDesired: REGSAM,
+        lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+        phkResult: PHKEY,
+        lpdwDisposition: LPDWORD
+    ) -> LONG;
+    pub fn RegCreateKeyExW(
+        hKey: HKEY,
+        lpSubKey: LPCWSTR,
+        Reserved: DWORD,
+        lpClass: LPCWSTR,
+        dwOptions: DWORD,
+        samDesired: REGSAM,
+        lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+        phkResult: PHKEY,
+        lpdwDisposition: LPDWORD
+    ) -> LONG;
+    pub fn RegDeleteKeyA(
+        hKey: HKEY,
+        lpSubKey: LPCSTR
+    ) -> LONG;
+    pub fn RegDeleteKeyW(
+        hKey: HKEY,
+        lpSubKey: LPCWSTR
+    ) -> LONG;
+    pub fn RegDeleteKeyExA(
+        hKey: HKEY,
+        lpSubKey: LPCSTR,
+        samDesired: REGSAM,
+        Reserved: DWORD
+    ) -> LONG;
+    pub fn RegDeleteKeyExW(
+        hKey: HKEY,
+        lpSubKey: LPCWSTR,
+        samDesired: REGSAM,
+        Reserved: DWORD
+    ) -> LONG;
+    pub fn RegDeleteKeyValueA(
+        hKey: HKEY,
+        lpSubKey: LPCSTR,
+        lpValueName: LPCSTR
+    ) -> LONG;
+    pub fn RegDeleteKeyValueW(
+        hKey: HKEY,
+        lpSubKey: LPCWSTR,
+        lpValueName: LPCWSTR
+    ) -> LONG;
+    pub fn RegDeleteTreeA(
+        hKey: HKEY,
+        lpSubKey: LPCSTR
+    ) -> LONG;
+    pub fn RegDeleteTreeW(
+        hKey: HKEY,
+        lpSubKey: LPCWSTR
+    ) -> LONG;
+    pub fn RegDeleteValueA(
+        hKey: HKEY,
+        lpValueName: LPCSTR
+    ) -> LONG;
+    pub fn RegDeleteValueW(
+        hKey: HKEY,
+        lpValueName: LPCWSTR
+    ) -> LONG;
+    pub fn RegDisablePredefinedCache() -> LONG;
+    pub fn RegDisablePredefinedCacheEx() -> LONG;
+    pub fn RegDisableReflectionKey(
+        hBase: HKEY
+    ) -> LONG;
+    pub fn RegEnableReflectionKey(
+        hBase: HKEY
+    ) -> LONG;
+    pub fn RegEnumKeyExA(
+        hKey: HKEY,
+        dwIndex: DWORD,
+        lpName: LPSTR,
+        lpcName: LPDWORD,
+        lpReserved: LPDWORD,
+        lpClass: LPSTR,
+        lpcClass: LPDWORD,
+        lpftLastWriteTime: PFILETIME
+    ) -> LONG;
+    pub fn RegEnumKeyExW(
+        hKey: HKEY,
+        dwIndex: DWORD,
+        lpName: LPWSTR,
+        lpcName: LPDWORD,
+        lpReserved: LPDWORD,
+        lpClass: LPWSTR,
+        lpcClass: LPDWORD,
+        lpftLastWriteTime: PFILETIME
+    ) -> LONG;
+    pub fn RegEnumValueA(
+        hKey: HKEY,
+        dwIndex: DWORD,
+        lpValueName: LPSTR,
+        lpcchValueName: LPDWORD,
+        lpReserved: LPDWORD,
+        lpType: LPDWORD,
+        lpData: LPBYTE,
+        lpcbData: LPDWORD
+    ) -> LONG;
+    pub fn RegEnumValueW(
+        hKey: HKEY,
+        dwIndex: DWORD,
+        lpValueName: LPWSTR,
+        lpcchValueName: LPDWORD,
+        lpReserved: LPDWORD,
+        lpType: LPDWORD,
+        lpData: LPBYTE,
+        lpcbData: LPDWORD
+    ) -> LONG;
+    pub fn RegFlushKey(
+        hKey: HKEY
+    ) -> LONG;
+    pub fn RegGetValueA(
+         hkey: HKEY,
+         lpSubKey: LPCSTR,
+         lpValue: LPCSTR,
+         dwFlags: DWORD,
+         pdwType: LPDWORD,
+         pvData: PVOID,
+         pcbData: LPDWORD
+    ) -> LONG;
+    pub fn RegGetValueW(
+         hkey: HKEY,
+         lpSubKey: LPCWSTR,
+         lpValue: LPCWSTR,
+         dwFlags: DWORD,
+         pdwType: LPDWORD,
+         pvData: PVOID,
+         pcbData: LPDWORD
+    ) -> LONG;
+    pub fn RegLoadMUIStringW(
+        hKey: HKEY,
+        pszValue: LPCWSTR,
+        pszOutBuf: LPWSTR,
+        cbOutBuf: DWORD,
+        pcbData: LPDWORD,
+        Flags: DWORD,
+        pszDirectory: LPCWSTR
+    ) -> LONG;
+    pub fn RegNotifyChangeKeyValue(
+        hKey: HKEY,
+        bWatchSubtree: BOOL,
+        dwNotifyFilter: DWORD,
+        hEvent: HANDLE,
+        fAsynchronous: BOOL
+    ) -> LONG;
+    pub fn RegOpenCurrentUser(
+        samDesired: REGSAM,
+        phkResult: PHKEY
+    ) -> LONG;
+    pub fn RegOpenKeyExA(
+        hKey: HKEY,
+        lpSubKey: LPCSTR,
+        ulOptions: DWORD,
+        samDesired: REGSAM,
+        phkResult: PHKEY
+    ) -> LONG;
+    pub fn RegOpenKeyExW(
+        hKey: HKEY,
+        lpSubKey: LPCWSTR,
+        ulOptions: DWORD,
+        samDesired: REGSAM,
+        phkResult: PHKEY
+    ) -> LONG;
+    pub fn RegOpenUserClassesRoot(
+        hToken: HANDLE,
+        dwOptions: DWORD,
+        samDesired: REGSAM,
+        phkResult: PHKEY
+    ) -> LONG;
+    pub fn RegOverridePredefKey(
+        hKey: HKEY,
+        hNewHKey: HKEY
+    ) -> LONG;
+    pub fn RegQueryInfoKeyA(
+        hKey: HKEY,
+        lpClass: LPSTR,
+        lpcClass: LPDWORD,
+        lpReserved: LPDWORD,
+        lpcSubKeys: LPDWORD,
+        lpcMaxSubKeyLen: LPDWORD,
+        lpcMaxClassLen: LPDWORD,
+        lpcValues: LPDWORD,
+        lpcMaxValueNameLen: LPDWORD,
+        lpcMaxValueLen: LPDWORD,
+        lpcbSecurityDescriptor: LPDWORD,
+        lpftLastWriteTime: PFILETIME
+    ) -> LONG;
+    pub fn RegQueryInfoKeyW(
+        hKey: HKEY,
+        lpClass: LPWSTR,
+        lpcClass: LPDWORD,
+        lpReserved: LPDWORD,
+        lpcSubKeys: LPDWORD,
+        lpcMaxSubKeyLen: LPDWORD,
+        lpcMaxClassLen: LPDWORD,
+        lpcValues: LPDWORD,
+        lpcMaxValueNameLen: LPDWORD,
+        lpcMaxValueLen: LPDWORD,
+        lpcbSecurityDescriptor: LPDWORD,
+        lpftLastWriteTime: PFILETIME
+    ) -> LONG;
+    pub fn RegQueryMultipleValuesA(
+        hKey: HKEY,
+        val_list: PVALENTA,
+        num_vals: DWORD,
+        lpValueBuf: LPSTR,
+        ldwTotsize: LPDWORD
+    ) -> LONG;
+    pub fn RegQueryMultipleValuesW(
+        hKey: HKEY,
+        val_list: PVALENTW,
+        num_vals: DWORD,
+        lpValueBuf: LPWSTR,
+        ldwTotsize: LPDWORD
+    ) -> LONG;
+    pub fn RegQueryReflectionKey(
+        hBase: HKEY,
+        bIsReflectionDisabled: PBOOL
+    ) -> LONG;
+    pub fn RegQueryValueExA(
+        hKey: HKEY,
+        lpValueName: LPCSTR,
+        lpReserved: LPDWORD,
+        lpType: LPDWORD,
+        lpData: LPBYTE,
+        lpcbData: LPDWORD
+    ) -> LONG;
+    pub fn RegQueryValueExW(
+        hKey: HKEY,
+        lpValueName: LPCWSTR,
+        lpReserved: LPDWORD,
+        lpType: LPDWORD,
+        lpData: LPBYTE,
+        lpcbData: LPDWORD
+    ) -> LONG;
+    pub fn RegSetKeyValueA(
+        hKey: HKEY,
+        lpSubKey: LPCSTR,
+        lpValueName: LPCSTR,
+        dwType: DWORD,
+        lpData: LPCVOID,
+        cbData: DWORD
+    ) -> LONG;
+    pub fn RegSetKeyValueW(
+        hKey: HKEY,
+        lpSubKey: LPCWSTR,
+        lpValueName: LPCWSTR,
+        dwType: DWORD,
+        lpData: LPCVOID,
+        cbData: DWORD
+    ) -> LONG;
+    pub fn RegSetValueExA(
+        hKey: HKEY,
+        lpValueName: LPCSTR,
+        Reserved: DWORD,
+        dwType: DWORD,
+        lpData: *const BYTE,
+        cbData: DWORD
+    ) -> LONG;
+    pub fn RegSetValueExW(
+        hKey: HKEY,
+        lpValueName: LPCWSTR,
+        Reserved: DWORD,
+        dwType: DWORD,
+        lpData: *const BYTE,
+        cbData: DWORD
+    ) -> LONG;
 }
 #[cfg(feature = "winmm")]
 #[link(name = "winmm")]


### PR DESCRIPTION
- [x] GetSystemRegistryQuota
- [x] RegCloseKey
- [x] RegConnectRegistry
- [x] RegCopyTree
- [x] RegCreateKeyEx
- RegCreateKeyTransacted (needs [Kernel Transaction Manager API](http://msdn.microsoft.com/en-us/library/windows/desktop/bb986748%28v=vs.85%29.aspx))
- [x] RegDeleteKey
- [x] RegDeleteKeyEx
- RegDeleteKeyTransacted (needs [Kernel Transaction Manager API](http://msdn.microsoft.com/en-us/library/windows/desktop/bb986748%28v=vs.85%29.aspx))
- [x] RegDeleteKeyValue
- [x] RegDeleteTree
- [x] RegDeleteValue
- [x] RegDisablePredefinedCache
- [x] RegDisablePredefinedCacheEx
- [x] RegDisableReflectionKey
- [x] RegEnableReflectionKey
- [x] RegEnumKeyEx
- [x] RegEnumValue
- [x] RegFlushKey
- RegGetKeySecurity (needs [Authorization API](http://msdn.microsoft.com/en-us/library/windows/desktop/aa375769%28v=vs.85%29.aspx))
- [x] RegGetValue
- RegLoadKey (needs [Enabling priviledges](http://msdn.microsoft.com/en-us/library/aa446619%28VS.85%29.aspx))
- [x] RegLoadMUIString
- [x] RegNotifyChangeKeyValue
- [x] RegOpenCurrentUser
- [x] RegOpenKeyEx
- RegOpenKeyTransacted (needs [Kernel Transaction Manager API](http://msdn.microsoft.com/en-us/library/windows/desktop/bb986748%28v=vs.85%29.aspx))
- [x] RegOpenUserClassesRoot
- [x] RegOverridePredefKey
- [x] RegQueryInfoKey
- [x] RegQueryMultipleValues
- [x] RegQueryReflectionKey
- [x] RegQueryValueEx
- RegReplaceKey (needs [Enabling priviledges](http://msdn.microsoft.com/en-us/library/aa446619%28VS.85%29.aspx))
- RegRestoreKey (needs [Enabling priviledges](http://msdn.microsoft.com/en-us/library/aa446619%28VS.85%29.aspx))
- RegSaveKey (needs [Enabling priviledges](http://msdn.microsoft.com/en-us/library/aa446619%28VS.85%29.aspx))
- RegSaveKeyEx (needs [Enabling priviledges](http://msdn.microsoft.com/en-us/library/aa446619%28VS.85%29.aspx))
- [x] RegSetKeyValue
- RegSetKeySecurity (needs [Authorization API](http://msdn.microsoft.com/en-us/library/windows/desktop/aa375769%28v=vs.85%29.aspx))
- [x] RegSetValueEx
- RegUnLoadKey (needs [Enabling priviledges](http://msdn.microsoft.com/en-us/library/aa446619%28VS.85%29.aspx))

Usage example:

``` rust
extern crate winapi;
use std::{fmt,mem,os,ptr};
use RegValue::{SZ,DWORD};

enum RegValue {
    SZ(String),
    DWORD(winapi::DWORD)
}

impl fmt::Show for RegValue {
    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
        match *self {
            SZ(ref s) => write!(f, "SZ({})", s),
            DWORD(n) => write!(f, "DWORD({})", n)
        }
    }
}

fn create_key(h_key: winapi::HKEY, subkey: &str, opts: winapi::DWORD, perms: winapi::REGSAM)
-> Result<winapi::HKEY, uint> {
    let subkey_cstr = subkey.to_c_str();
    let mut new_hkey: winapi::HKEY = ptr::null_mut();
    let mut disp: winapi::DWORD = 0;
    match unsafe{
        winapi::RegCreateKeyExA(
            h_key,
            subkey_cstr.as_ptr(),
            0,
            ptr::null(),
            opts,
            perms,
            ptr::null_mut(),
            &mut new_hkey,
            &mut disp //created new key or opened existing one, ignored in this example
        )
    } {
        0 => Ok(new_hkey),
        err => Err(err as uint)
    }
}

fn close_key(h_key: winapi::HKEY) -> Result<(), uint> {
    match unsafe{
        winapi::RegCloseKey(h_key)
    } {
        0 => Ok(()),
        err => Err(err as uint)
    }
}

fn set_value(h_key: winapi::HKEY, name: &str, value: &RegValue) -> Result<(), uint> {
    let name_c = name.to_c_str();
    match unsafe{
        match *value {
            RegValue::SZ(ref s) => winapi::RegSetValueExA(
                h_key,
                name_c.as_ptr(),
                0,
                winapi::REG_SZ,
                s.to_c_str().as_ptr() as *const winapi::BYTE,
                (s.len()+1) as u32),
            RegValue::DWORD(n) => {
                let buf: [u8, ..4] = mem::transmute(n);
                winapi::RegSetValueExA(
                    h_key,
                    name_c.as_ptr(),
                    0,
                    winapi::REG_DWORD,
                    buf.as_ptr() as *const winapi::BYTE,
                    4u32)
            }
        }
    } {
        0 => Ok(()),
        err => Err(err as uint)
    }
}

fn query_value(h_key: winapi::HKEY, name: &str) -> Result<RegValue, uint> {
    let name_c = name.to_c_str();
    let mut vtype: winapi::DWORD = 0;
    let mut buf_len: winapi::DWORD = winapi::MAX_PATH as winapi::DWORD;
    let mut buf: Vec<u8> = Vec::with_capacity(buf_len as uint);
    match unsafe{
        winapi::RegQueryValueExA(
            h_key,
            name_c.as_ptr() as *const i8,
            ptr::null_mut(),
            &mut vtype,
            buf.as_mut_ptr() as winapi::LPBYTE,
            &mut buf_len
        )
    } {
        0 => match vtype {
            winapi::REG_SZ => {
                Ok(RegValue::SZ(unsafe{
                    String::from_raw_buf_len(buf.as_ptr(), (buf_len - 1) as uint)
                }))
            },
            winapi::REG_DWORD => {
                Ok(RegValue::DWORD(unsafe{
                    buf.set_len(4);
                    (buf[3] as u32 << 24) | (buf[2] as u32 << 16) |
                        (buf[1] as u32 << 8) | (buf[0] as u32)
                }))
            },
            _ => Err(13) //invalid data error
        },
        err => Err(err as uint)
    }
}

fn main() {
    let h_key = create_key(winapi::HKEY_CURRENT_USER, "Software\\RegistrySampleRustA",
            winapi::REG_OPTION_NON_VOLATILE, winapi::KEY_ALL_ACCESS)
    .unwrap_or_else(|i| panic!(os::error_string(i)));

    let name_sz = "Test string";
    set_value(h_key, name_sz, &RegValue::SZ("This is a test".to_string()))
    .unwrap_or_else(|i| panic!(os::error_string(i)));

    let val_sz = query_value(h_key, name_sz)
    .unwrap_or_else(|i| panic!(os::error_string(i)));
    println!("{}", val_sz);

    let name_dw = "Test number";
    set_value(h_key, name_dw, &RegValue::DWORD(1234567))
    .unwrap_or_else(|i| panic!(os::error_string(i)));

    let val_dw = query_value(h_key, name_dw)
    .unwrap_or_else(|i| panic!(os::error_string(i)));
    println!("{}", val_dw);

    close_key(h_key).unwrap_or_else(|i: uint| panic!(os::error_string(i)));
}
```

Example with unicode:

``` rust
extern crate winapi;
use std::{os,ptr};

fn main() {
    let mut h_key: winapi::HKEY = ptr::null_mut();
    let mut disp: winapi::DWORD = 0;
    let mut path_w: Vec<u16> = "Software\\RegistrySampleRustW\\".utf16_units().collect();
    path_w.push(0);
    let res_w = unsafe{
        winapi::RegCreateKeyExW(
            winapi::HKEY_CURRENT_USER,
            path_w.as_ptr(),
            0,
            ptr::null(),
            winapi::REG_OPTION_NON_VOLATILE,
            winapi::KEY_WRITE,
            ptr::null_mut(),
            &mut h_key,
            &mut disp
        )
    };
    println!("RegCreateKeyExW returned {}, disposition = {}",
        os::error_string(res_w as uint), disp);
}


```
