### PR TITLE
Add bindings for setting clipboard data

### DIFF
--- a/lib/kernel32-sys/src/lib.rs
+++ b/lib/kernel32-sys/src/lib.rs
@@ -852,7 +852,7 @@ extern "system" {
     // pub fn GlobalAddAtomExA();
     // pub fn GlobalAddAtomExW();
     // pub fn GlobalAddAtomW();
-    // pub fn GlobalAlloc();
+    pub fn GlobalAlloc(uFlags: UINT, dwBytes: SIZE_T) -> HGLOBAL;
     // pub fn GlobalCompact();
     // pub fn GlobalDeleteAtom();
     // pub fn GlobalFindAtomA();
@@ -863,14 +863,14 @@ extern "system" {
     // pub fn GlobalGetAtomNameA();
     // pub fn GlobalGetAtomNameW();
     // pub fn GlobalHandle();
-    // pub fn GlobalLock();
+    pub fn GlobalLock(hMem: HGLOBAL) -> LPVOID;
     // pub fn GlobalMemoryStatus();
     // pub fn GlobalMemoryStatusEx();
     // pub fn GlobalReAlloc();
     // pub fn GlobalSize();
     // pub fn GlobalUnWire();
     // pub fn GlobalUnfix();
-    // pub fn GlobalUnlock();
+    pub fn GlobalUnlock(hMem: HGLOBAL) -> BOOL;
     // pub fn GlobalWire();
     // pub fn Heap32First();
     // pub fn Heap32ListFirst();

--- a/lib/user32-sys/src/lib.rs
+++ b/lib/user32-sys/src/lib.rs
@@ -765,7 +765,7 @@ extern "system" {
     pub fn SetClassLongPtrW(hWnd: HWND, nIndex: c_int, dwNewLong: LONG_PTR) -> ULONG_PTR;
     pub fn SetClassLongW(hWnd: HWND, nIndex: c_int, dwNewLong: LONG) -> DWORD;
     pub fn SetClassWord(hWnd: HWND, nIndex: c_int, wNewWord: WORD) -> WORD;
-    // pub fn SetClipboardData();
+    pub fn SetClipboardData(uFormat: UINT, hMem: HANDLE) -> HANDLE;
     pub fn SetClipboardViewer(hWndNewViewer: HWND) -> HWND;
     // pub fn SetCoalescableTimer();
     pub fn SetCursor(hCursor: HCURSOR) -> HCURSOR;


### PR DESCRIPTION
It looks like #39 added bindings to get clipboard data, but not to set it.

Based on the MSDN article on [Copying Information to the Clipboard](https://msdn.microsoft.com/en-us/library/windows/desktop/ms649016%28v=vs.85%29.aspx#_win32_Copying_Information_to_the_Clipboard), this adds bindings to set clipboard data.

I've verified that these work by using them in the test suite for my [pbpaste-rs](https://github.com/toolness/pbpaste-rs) program.

This is my first PR to any Rust project, so apologies if I messed anything up!