### PR TITLE
kernel32: add GlobalFree() function

### DIFF
--- a/lib/kernel32-sys/src/lib.rs
+++ b/lib/kernel32-sys/src/lib.rs
@@ -917,7 +917,7 @@ extern "system" {
     // pub fn GlobalFindAtomW();
     // pub fn GlobalFix();
     // pub fn GlobalFlags();
-    // pub fn GlobalFree();
+    pub fn GlobalFree(hMem: HGLOBAL) -> HGLOBAL;
     // pub fn GlobalGetAtomNameA();
     // pub fn GlobalGetAtomNameW();
     // pub fn GlobalHandle();


### PR DESCRIPTION
Mainly this is the same as ```LocalFree()```
I may need this function for my create as memory which is allocated by ```GlobalAlloc()``` cannot be safely freed by ```LocalFree()```