### PR TITLE
Kernel32: Enable "Customer Experience Improvement Program" check

### DIFF
--- a/lib/kernel32-sys/src/lib.rs
+++ b/lib/kernel32-sys/src/lib.rs
@@ -64,7 +64,7 @@ extern "system" {
     // pub fn CancelThreadpoolIo();
     // pub fn CancelTimerQueueTimer();
     // pub fn CancelWaitableTimer();
-    // pub fn CeipIsOptedIn();
+    pub fn CeipIsOptedIn() -> BOOL;
     // pub fn ChangeTimerQueueTimer();
     // pub fn CheckElevation();
     // pub fn CheckElevationEnabled();


### PR DESCRIPTION
I haven't had any :coffee: yet, so let's just start with a small PR. 

This function works in Windows Server 2012 R2 (and above) and Windows 8.1/10 (and future versions, hopefully) and returns true if the CEIP has been enabled for the computer being checked.

There aren't any *current* use cases, but I'll need it in a pet project that I'm hoping to eventually market. Otherwise, open-source :)

This function checks to see if the Customer Experience Improvement Program is enabled.

I don't know exactly what CEIP users have uploaded to Microsoft. Maybe sensitive information? Who knows...


***********************

Also, since this only works in relatively newer versions of Windows, I wasn't sure if I should `bb` this function in the functions test. Is that mainly for functions that have been around since, say, XP or Vista/7? I don't want to break everything :(