### PR TITLE
Add a new macro for multiple inheritance.

### DIFF
--- a/src/vsbackup.rs
+++ b/src/vsbackup.rs
@@ -75,16 +75,12 @@ interface IVssExamineWriterMetadata(IVssExamineWriterMetadataVtbl): IUnknown(IUn
 
 // class IVssExamineWriterMetadataEx2
 
-#[repr(C)] #[allow(missing_copy_implementations)]
-pub struct IVssWriterComponentsExt {
-    pub lpVtbl: *mut IVssWriterComponentsExtVtbl,
+RIDL!(
+interface IVssWriterComponentsExt(IVssWriterComponentsExtVtbl):
+    IVssWriterComponents(IVssWriterComponentsVtbl, parent1),
+    IUnknown(IUnknownVtbl, parent2) {
 }
-#[repr(C)]
-pub struct IVssWriterComponentsExtVtbl {
-    pub parent1: ::IVssWriterComponentsVtbl,
-    pub parent2: ::IUnknownVtbl,
-}
-
+);
 
 RIDL!(
 interface IVssBackupComponents(IVssBackupComponentsVtbl): IUnknown(IUnknownVtbl) {


### PR DESCRIPTION
How do you feel about 2 new macro patterns for RIDL:

1.  Support multiple inheritance.
2.  Support multiple inheritance with no new methods.

It's a little messier since you have to specify the names of the fields.