### PR TITLE
Kernel32: Enable beeping.

### DIFF
--- a/lib/kernel32-sys/src/lib.rs
+++ b/lib/kernel32-sys/src/lib.rs
@@ -45,7 +45,7 @@ extern "system" {
     // pub fn BackupSeek();
     // pub fn BackupWrite();
     // pub fn BaseSetLastNTError();
-    // pub fn Beep();
+    pub fn Beep(dwFreq: DWORD, dwDuration: DWORD) -> BOOL;
     // pub fn BeginUpdateResourceA();
     // pub fn BeginUpdateResourceW();
     // pub fn BindIoCompletionCallback();


### PR DESCRIPTION
Previously, kernel32-sys was unsuitable for use in cars. Also unsuitable for prank programs that require a beep that bypasses a system mute.

I take no responsibility for any future use that causes data centre owners to require earmuffs or deafness as a job requirement.

I wonder what that would be like, a room full of constantly beeping servers...

**************************************

I didn't set out to do this, just noticed that it was disabled while working on another quick PR. Have fun :)