### PR TITLE
Add [Get,Set][Window,Class]LongPtr[A,W] for x86

### DIFF
--- a/lib/user32-sys/src/lib.rs
+++ b/lib/user32-sys/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License <LICENSE.md>
 //! FFI bindings to user32.
 #![cfg(windows)]
+#![allow(non_snake_case)]
 extern crate winapi;
 use winapi::*;
 extern "system" {
@@ -1076,4 +1077,37 @@ extern "system" {
     // pub fn wsprintfW();
     // pub fn wvsprintfA();
     // pub fn wvsprintfW();
+}
+
+#[cfg(target_arch = "x86")] #[inline]
+pub unsafe fn GetClassLongPtrA(hWnd: HWND, nIndex: c_int) -> ULONG_PTR {
+    GetClassLongA(hWnd, nIndex)
+}
+#[cfg(target_arch = "x86")] #[inline]
+pub unsafe fn GetClassLongPtrW(hWnd: HWND, nIndex: c_int) -> ULONG_PTR {
+    GetClassLongW(hWnd, nIndex)
+}
+#[cfg(target_arch = "x86")] #[inline]
+pub unsafe fn GetWindowLongPtrA(hWnd: HWND, nIndex: c_int) -> LONG_PTR {
+    GetWindowLongA(hWnd, nIndex)
+}
+#[cfg(target_arch = "x86")] #[inline]
+pub unsafe fn GetWindowLongPtrW(hWnd: HWND, nIndex: c_int) -> LONG_PTR {
+    GetWindowLongW(hWnd, nIndex)
+}
+#[cfg(target_arch = "x86")] #[inline]
+pub unsafe fn SetClassLongPtrA(hWnd: HWND, nIndex: c_int, dwNewLong: LONG_PTR) -> ULONG_PTR {
+    SetClassLongA(hWnd, nIndex, dwNewLong)
+}
+#[cfg(target_arch = "x86")] #[inline]
+pub unsafe fn SetClassLongPtrW(hWnd: HWND, nIndex: c_int, dwNewLong: LONG_PTR) -> ULONG_PTR {
+    SetClassLongW(hWnd, nIndex, dwNewLong)
+}
+#[cfg(target_arch = "x86")] #[inline]
+pub unsafe fn SetWindowLongPtrA(hWnd: HWND, nIndex: c_int, dwNewLong: LONG_PTR) -> LONG_PTR {
+    SetWindowLongA(hWnd, nIndex, dwNewLong)
+}
+#[cfg(target_arch = "x86")] #[inline]
+pub unsafe fn SetWindowLongPtrW(hWnd: HWND, nIndex: c_int, dwNewLong: LONG_PTR) -> LONG_PTR {
+    SetWindowLongW(hWnd, nIndex, dwNewLong)
 }


### PR DESCRIPTION
The `*LongPtr*` functions are #defined to `*Long*` for non-`_WIN64` builds but defining them within `winapi` would introduce a dependency to `user32-sys` so I put them into the import lib which is non-canonical ... Nasty one way or the other.