### PR TITLE
Implement std::fmt::Display for GUID

### DIFF
--- a/src/guiddef.rs
+++ b/src/guiddef.rs
@@ -1,5 +1,7 @@
 // Copyright © 2015, Peter Atashian
 // Licensed under the MIT License <LICENSE.md>
+use std::fmt;
+
 #[repr(C)] #[derive(Clone, Copy, Debug)]
 pub struct GUID {
     pub Data1: ::c_ulong,
@@ -19,3 +21,12 @@ pub type REFGUID = *const GUID;
 pub type REFIID = *const IID;
 pub type REFCLSID = *const IID;
 pub type REFFMTID = *const IID;
+
+impl fmt::Display for GUID {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
+            self.Data1, self.Data2, self.Data3,
+            self.Data4 [0], self.Data4 [1], self.Data4 [2], self.Data4 [3],
+            self.Data4 [4], self.Data4 [5], self.Data4 [6], self.Data4 [7])
+    }
+}


### PR DESCRIPTION
```rust
print!("{}", guid);
```
will print the string representation of `GUID`