### PR TITLE
Fixed handle type to foreign-function safe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub use xinput::*;
 //-------------------------------------------------------------------------------------------------
 macro_rules! DECLARE_HANDLE {
     ($name:ident, $inner:ident) => {
-        #[repr(C)] #[allow(missing_copy_implementations)] struct $inner { unused: () }
+        #[repr(C)] #[allow(missing_copy_implementations)] struct $inner { unused: ::c_void }
         pub type $name = *mut $inner;
     };
 }


### PR DESCRIPTION
It looks like new rust compiler is giving warnings about the type DECLARE_HANDLE generates.
I changed *non-foreign-function safe* type to foreign-function safe.