### PR TITLE
build: avoid panicing build script if target does split to >2 elements

### DIFF
--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -4,7 +4,7 @@ pub fn link(name: &str, bundled: bool) {
     use std::env::var;
     let target = var("TARGET").unwrap();
     let target: Vec<_> = target.split('-').collect();
-    if target[2] == "windows" {
+    if target.len() > 2 && target[2] == "windows" {
         println!("cargo:rustc-link-lib=dylib={}", name);
         if bundled && target[3] == "gnu" {
             let dir = var("CARGO_MANIFEST_DIR").unwrap();

--- a/build/src/lib.rs
+++ b/build/src/lib.rs
@@ -6,7 +6,7 @@ pub fn link(name: &str, bundled: bool) {
     let target: Vec<_> = target.split('-').collect();
     if target.len() > 2 && target[2] == "windows" {
         println!("cargo:rustc-link-lib=dylib={}", name);
-        if bundled && target[3] == "gnu" {
+        if bundled && target.len() > 3 && target[3] == "gnu" {
             let dir = var("CARGO_MANIFEST_DIR").unwrap();
             println!("cargo:rustc-link-search=native={}/{}", dir, target[0]);
         }


### PR DESCRIPTION
In meta-rust, I've observed failures caused by missing the first length check.

I haven't seen any failures caused by the second (because I'm not building anything for windows) but I don't see a reason not to check for it.