### PR TITLE
Fix CreateEventExW

### DIFF
--- a/lib/kernel32/src/lib.rs
+++ b/lib/kernel32/src/lib.rs
@@ -226,7 +226,7 @@ extern "system" {
         dwDesiredAccess: DWORD,
     ) -> HANDLE;
     pub fn CreateEventExW(
-        lpEventAttributes: LPSECURITY_ATTRIBUTES, lpName: LPWSTR, dwFlags: DWORD,
+        lpEventAttributes: LPSECURITY_ATTRIBUTES, lpName: LPCWSTR, dwFlags: DWORD,
         dwDesiredAccess: DWORD,
     ) -> HANDLE;
     pub fn CreateFiber(


### PR DESCRIPTION
Fixes a wrong function signature for `CreateEventExW`.

From the MSDN documentation:
```c
HANDLE WINAPI CreateEventEx(
  _In_opt_ LPSECURITY_ATTRIBUTES lpEventAttributes,
  _In_opt_ LPCTSTR               lpName,
  _In_     DWORD                 dwFlags,
  _In_     DWORD                 dwDesiredAccess
);
```

`lpName` needs to be a *constant* null-terminated string.