### PR TITLE
Add .idea/ and *.iml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 Cargo.lock
+.idea/
+*.iml


### PR DESCRIPTION
Add IntelliJ project files to .gitignore.
Useful when developing with the [intellij-rust plugin](https://github.com/intellij-rust/intellij-rust).