### PR TITLE
Update README.md example to be target specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,10 @@ winmm-sys = "0.1"
 ```
 example.rs:
 ```Rust
-
 #[cfg(windows)] extern crate winapi;
 #[cfg(windows)] extern crate winmm;
+#[cfg(windows)]
 fn func() {
-    #[cfg(windows)]
     winmm::PlaySoundA(...);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ This crate depends on Rust 1.4 on Windows. On other platforms this crate is a no
 
 Cargo.toml:
 ```toml
-[dependencies]
+[target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 winmm-sys = "0.1"
 ```
 example.rs:
 ```Rust
-extern crate winapi;
-extern crate winmm;
+
+#[cfg(windows)] extern crate winapi;
+#[cfg(windows)] extern crate winmm;
 fn func() {
     winmm::PlaySoundA(...);
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ example.rs:
 #[cfg(windows)] extern crate winapi;
 #[cfg(windows)] extern crate winmm;
 fn func() {
+    #[cfg(windows)]
     winmm::PlaySoundA(...);
 }
 ```


### PR DESCRIPTION
Without target specific dependencies, Cargo will try to download and compile windows specific crates on other targets (for e.g.: unix).