### PR TITLE
Update libraries for 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ license = "MIT/Apache-2.0"
 include = ["src/**/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "build.rs", "README.md"]
 build = "build.rs"
 
+[build-dependencies]
+toml = "0.3"
+
 [target.i686-pc-windows-gnu.dependencies]
 winapi-i686-pc-windows-gnu = { version = "0.3", path = "i686" }
 [target.x86_64-pc-windows-gnu.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,15 +273,110 @@ headers = ["headers-shared", "headers-um", "headers-vc", "headers-winrt"]
 "winrt-hstring" = ["um-winnt"]
 "winrt-inspectable" = ["shared-guiddef", "shared-minwindef", "um-unknwnbase", "um-winnt", "winrt-hstring"]
 libraries = [
+    "avrt",
+    "advapi32",
+    "bcrypt",
+    "comctl32",
+    "comdlg32",
+    "credui",
+    "crypt32",
+    "d2d1",
+    "d3d11",
+    "d3d12",
+    "d3d9",
+    "d3dcompiler",
+    "dbghelp",
+    "dsound",
+    "dwmapi",
+    "dwrite",
+    "dxgi",
+    "dxguid",
+    "gdi32",
+    "hid",
+    "httpapi",
     "kernel32",
+    "ktmw32",
+    "mpr",
     "ncrypt",
+    "netapi32",
+    "ntdll",
+    "odbc32",
     "ole32",
+    "oleaut32",
+    "opengl32",
+    "pdh",
+    "psapi",
+    "runtimeobject",
+    "sapi",
+    "secur32",
     "setupapi",
+    "shcore",
+    "shell32",
+    "user32",
+    "userenv",
+    "usp10",
+    "uuid",
+    "version",
+    "vssapi",
+    "winhttp",
     "wininet",
+    "winmm",
+    "winscard",
+    "winspool",
+    "winusb",
+    "ws2_32",
+    "xinput",
 ]
 "avrt" = []
+"advapi32" = []
+"bcrypt" = []
+"comctl32" = []
+"comdlg32" = []
+"credui" = []
+"crypt32" = []
+"d2d1" = []
+"d3d11" = []
+"d3d12" = []
+"d3d9" = []
+"d3dcompiler" = []
+"dbghelp" = []
+"dsound" = []
+"dwmapi" = []
+"dwrite" = []
+"dxgi" = []
+"dxguid" = []
+"gdi32" = []
+"hid" = []
+"httpapi" = []
 "kernel32" = []
-"ole32" = []
+"ktmw32" = []
+"mpr" = []
 "ncrypt" = []
+"netapi32" = []
+"ntdll" = []
+"odbc32" = []
+"ole32" = []
+"oleaut32" = []
+"opengl32" = []
+"pdh" = []
+"psapi" = []
+"runtimeobject" = []
+"sapi" = []
+"secur32" = []
 "setupapi" = []
+"shcore" = []
+"shell32" = []
+"user32" = []
+"userenv" = []
+"usp10" = []
+"uuid" = []
+"version" = []
+"vssapi" = []
+"winhttp" = []
 "wininet" = []
+"winmm" = []
+"winscard" = []
+"winspool" = []
+"winusb" = []
+"ws2_32" = []
+"xinput" = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ license = "MIT/Apache-2.0"
 include = ["src/**/*", "Cargo.toml", "LICENSE-MIT", "LICENSE-APACHE", "build.rs", "README.md"]
 build = "build.rs"
 
-[build-dependencies]
-toml = "0.3"
-
 [target.i686-pc-windows-gnu.dependencies]
 winapi-i686-pc-windows-gnu = { version = "0.3", path = "i686" }
 [target.x86_64-pc-windows-gnu.dependencies]

--- a/build.rs
+++ b/build.rs
@@ -4,54 +4,26 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
-extern crate toml;
-
 use std::env::var;
-use std::fs::File;
-use std::io::Read;
-use std::path::PathBuf;
-use toml::Value;
-
+const LIBS: &'static [&'static str] = &[
+    "avrt",
+    "kernel32",
+    "ncrypt",
+    "ole32",
+    "setupapi",
+    "wininet",
+];
 fn main() {
     let target = var("TARGET").unwrap();
     let target: Vec<_> = target.split('-').collect();
     if target.get(2) == Some(&"windows") {
-        link_libs();
+        link_stuff();
     }
 }
-
-fn link_libs() {
-    for lib in collect_libs() {
+fn link_stuff() {
+    for lib in LIBS {
         if let Ok(_) = var(&format!("CARGO_FEATURE_{}", lib)) {
             println!("cargo:rustc-link-lib=dylib={}", lib);
         }
-    }
-}
-
-fn collect_libs() -> Vec<String> {
-    let manifest_dir = PathBuf::from(var("CARGO_MANIFEST_DIR").unwrap());
-    let name = manifest_dir.join("Cargo.toml");
-
-    let mut text = String::new();
-    File::open(&name)
-        .and_then(|mut file| file.read_to_string(&mut text))
-        .unwrap();
-
-    let toml: Value = text.parse().unwrap();
-    if let Value::Table(table) = toml {
-        let features = table.get("features").unwrap();
-        if let &Value::Array(ref libraries) = features.get("libraries").unwrap() {
-            let mut libs = Vec::new();
-            for value in libraries.into_iter() {
-                if let &Value::String(ref string) = value {
-                    libs.push(string.clone());
-                }
-            }
-            libs
-        } else {
-            panic!("Expected array");
-        }
-    } else {
-        panic!("Expected table");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -5,22 +5,72 @@
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
 use std::env::var;
+
 const LIBS: &'static [&'static str] = &[
     "avrt",
+    "advapi32",
+    "bcrypt",
+    "comctl32",
+    "comdlg32",
+    "credui",
+    "crypt32",
+    "d2d1",
+    "d3d11",
+    "d3d12",
+    "d3d9",
+    "d3dcompiler",
+    "dbghelp",
+    "dsound",
+    "dwmapi",
+    "dwrite",
+    "dxgi",
+    "dxguid",
+    "gdi32",
+    "hid",
+    "httpapi",
     "kernel32",
+    "ktmw32",
+    "mpr",
     "ncrypt",
+    "netapi32",
+    "ntdll",
+    "odbc32",
     "ole32",
+    "oleaut32",
+    "opengl32",
+    "pdh",
+    "psapi",
+    "runtimeobject",
+    "sapi",
+    "secur32",
     "setupapi",
+    "shcore",
+    "shell32",
+    "user32",
+    "userenv",
+    "usp10",
+    "uuid",
+    "version",
+    "vssapi",
+    "winhttp",
     "wininet",
+    "winmm",
+    "winscard",
+    "winspool",
+    "winusb",
+    "ws2_32",
+    "xinput",
 ];
+
 fn main() {
     let target = var("TARGET").unwrap();
     let target: Vec<_> = target.split('-').collect();
     if target.get(2) == Some(&"windows") {
-        link_stuff();
+        link_libs();
     }
 }
-fn link_stuff() {
+
+fn link_libs() {
     for lib in LIBS {
         if let Ok(_) = var(&format!("CARGO_FEATURE_{}", lib)) {
             println!("cargo:rustc-link-lib=dylib={}", lib);

--- a/build.rs
+++ b/build.rs
@@ -4,26 +4,54 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
+extern crate toml;
+
 use std::env::var;
-const LIBS: &'static [&'static str] = &[
-    "avrt",
-    "kernel32",
-    "ncrypt",
-    "ole32",
-    "setupapi",
-    "wininet",
-];
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+use toml::Value;
+
 fn main() {
     let target = var("TARGET").unwrap();
     let target: Vec<_> = target.split('-').collect();
     if target.get(2) == Some(&"windows") {
-        link_stuff();
+        link_libs();
     }
 }
-fn link_stuff() {
-    for lib in LIBS {
+
+fn link_libs() {
+    for lib in collect_libs() {
         if let Ok(_) = var(&format!("CARGO_FEATURE_{}", lib)) {
             println!("cargo:rustc-link-lib=dylib={}", lib);
         }
+    }
+}
+
+fn collect_libs() -> Vec<String> {
+    let manifest_dir = PathBuf::from(var("CARGO_MANIFEST_DIR").unwrap());
+    let name = manifest_dir.join("Cargo.toml");
+
+    let mut text = String::new();
+    File::open(&name)
+        .and_then(|mut file| file.read_to_string(&mut text))
+        .unwrap();
+
+    let toml: Value = text.parse().unwrap();
+    if let Value::Table(table) = toml {
+        let features = table.get("features").unwrap();
+        if let &Value::Array(ref libraries) = features.get("libraries").unwrap() {
+            let mut libs = Vec::new();
+            for value in libraries.into_iter() {
+                if let &Value::String(ref string) = value {
+                    libs.push(string.clone());
+                }
+            }
+            libs
+        } else {
+            panic!("Expected array");
+        }
+    } else {
+        panic!("Expected table");
     }
 }


### PR DESCRIPTION
This PR does:
- Parse list of libraries from `Cargo.toml` (replaces `LIBS` in `build.rs`).
- Adds more libraries, based on directory names in `lib`

Should be in line with #316.