### PR TITLE
Move all kernel32 fileapi functions to fileapi

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -98,7 +98,7 @@ const DATA: &'static [(&'static str, &'static [&'static str], &'static [&'static
     ("dwrite_2", &["basetsd", "d3d9types", "dcommon", "dwrite", "dwrite_1", "minwindef", "unknwnbase", "winnt"], &[]),
     ("dwrite_3", &["basetsd", "dcommon", "dwrite", "dwrite_1", "dwrite_2", "minwindef", "unknwnbase", "wingdi", "winnt"], &[]),
     ("errhandlingapi", &["basetsd", "minwindef", "winnt"], &[]),
-    ("fileapi", &["minwinbase", "minwindef", "winnt"], &[]),
+    ("fileapi", &["minwinbase", "minwindef", "winbase", "winnt"], &["kernel32"]),
     ("gl-gl", &[], &[]),
     ("handleapi", &["minwindef", "winnt"], &["kernel32"]),
     ("heapapi", &["basetsd", "minwindef"], &[]),

--- a/lib/kernel32/src/lib.rs
+++ b/lib/kernel32/src/lib.rs
@@ -33,7 +33,6 @@ extern "system" {
     // pub fn AppXGetOSMaxVersionTested();
     pub fn ApplicationRecoveryFinished(bSuccess: BOOL);
     pub fn ApplicationRecoveryInProgress(pbCancelled: PBOOL) -> HRESULT;
-    pub fn AreFileApisANSI() -> BOOL;
     pub fn AssignProcessToJobObject(hJob: HANDLE, hProcess: HANDLE) -> BOOL;
     pub fn BackupRead(
         hFile: HANDLE, lpBuffer: LPBYTE, nNumberOfBytesToRead: DWORD, lpNumberOfBytesRead: LPDWORD,
@@ -118,7 +117,6 @@ extern "system" {
     pub fn CloseThreadpoolWork(pwk: PTP_WORK);
     pub fn CommConfigDialogA(lpszName: LPCSTR, hWnd: HWND, lpCC: LPCOMMCONFIG) -> BOOL;
     pub fn CommConfigDialogW(lpszName: LPCWSTR, hWnd: HWND, lpCC: LPCOMMCONFIG) -> BOOL;
-    pub fn CompareFileTime(lpFileTime1: *const FILETIME, lpFileTime2: *const FILETIME) -> LONG;
     pub fn CompareStringA(
         Locale: LCID, dwCmpFlags: DWORD, lpString1: PCNZCH, cchCount1: c_int, lpString2: PCNZCH,
         cchCount2: c_int,
@@ -174,9 +172,6 @@ extern "system" {
     pub fn CreateActCtxW(pActCtx: PCACTCTXW) -> HANDLE;
     pub fn CreateBoundaryDescriptorA(Name: LPCSTR, Flags: ULONG) -> HANDLE;
     pub fn CreateBoundaryDescriptorW(Name: LPCWSTR, Flags: ULONG) -> HANDLE;
-    pub fn CreateDirectoryA(
-        lpPathName: LPCSTR, lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
-    ) -> BOOL;
     pub fn CreateDirectoryExA(
         lpTemplateDirectory: LPCSTR, lpNewDirectory: LPCSTR,
         lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
@@ -193,9 +188,6 @@ extern "system" {
         lpTemplateDirectory: LPCWSTR, lpNewDirectory: LPCWSTR,
         lpSecurityAttributes: LPSECURITY_ATTRIBUTES, hTransaction: HANDLE,
     ) -> BOOL;
-    pub fn CreateDirectoryW(
-        lpPathName: LPCWSTR, lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
-    ) -> BOOL;
     pub fn CreateFiber(
         dwStackSize: SIZE_T, lpStartAddress: LPFIBER_START_ROUTINE, lpParameter: LPVOID,
     ) -> LPVOID;
@@ -203,15 +195,6 @@ extern "system" {
         dwStackCommitSize: SIZE_T, dwStackReserveSize: SIZE_T, dwFlags: DWORD,
         lpStartAddress: LPFIBER_START_ROUTINE, lpParameter: LPVOID,
     ) -> LPVOID;
-    pub fn CreateFile2(
-        lpFileName: LPCWSTR, dwDesiredAccess: DWORD, dwShareMode: DWORD,
-        dwCreationDisposition: DWORD, pCreateExParams: LPCREATEFILE2_EXTENDED_PARAMETERS,
-    ) -> HANDLE;
-    pub fn CreateFileA(
-        lpFileName: LPCSTR, dwDesiredAccess: DWORD, dwShareMode: DWORD,
-        lpSecurityAttributes: LPSECURITY_ATTRIBUTES, dwCreationDisposition: DWORD,
-        dwFlagsAndAttributes: DWORD, hTemplateFile: HANDLE,
-    ) -> HANDLE;
     pub fn CreateFileMappingA(
         hFile: HANDLE, lpAttributes: LPSECURITY_ATTRIBUTES, flProtect: DWORD,
         dwMaximumSizeHigh: DWORD, dwMaximumSizeLow: DWORD, lpName: LPCSTR,
@@ -243,11 +226,6 @@ extern "system" {
         lpSecurityAttributes: LPSECURITY_ATTRIBUTES, dwCreationDisposition: DWORD,
         dwFlagsAndAttributes: DWORD, hTemplateFile: HANDLE, hTransaction: HANDLE,
         pusMiniVersion: PUSHORT, lpExtendedParameter: PVOID,
-    ) -> HANDLE;
-    pub fn CreateFileW(
-        lpFileName: LPCWSTR, dwDesiredAccess: DWORD, dwShareMode: DWORD,
-        lpSecurityAttributes: LPSECURITY_ATTRIBUTES, dwCreationDisposition: DWORD,
-        dwFlagsAndAttributes: DWORD, hTemplateFile: HANDLE,
     ) -> HANDLE;
     pub fn CreateHardLinkA(
         lpFileName: LPCSTR, lpExistingFileName: LPCSTR, lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
@@ -386,15 +364,12 @@ extern "system" {
     pub fn DecodePointer(Ptr: PVOID) -> PVOID;
     pub fn DecodeSystemPointer(Ptr: PVOID) -> PVOID;
     pub fn DefineDosDeviceA(dwFlags: DWORD, lpDeviceName: LPCSTR, lpTargetPath: LPCSTR) -> BOOL;
-    pub fn DefineDosDeviceW(dwFlags: DWORD, lpDeviceName: LPCWSTR, lpTargetPath: LPCWSTR) -> BOOL;
     pub fn DelayLoadFailureHook(pszDllName: LPCSTR, pszProcName: LPCSTR) -> FARPROC;
     pub fn DeleteAtom(nAtom: ATOM) -> ATOM;
     pub fn DeleteBoundaryDescriptor(BoundaryDescriptor: HANDLE);
     pub fn DeleteFiber(lpFiber: LPVOID);
-    pub fn DeleteFileA(lpFileName: LPCSTR) -> BOOL;
     pub fn DeleteFileTransactedA(lpFileName: LPCSTR, hTransaction: HANDLE) -> BOOL;
     pub fn DeleteFileTransactedW(lpFileName: LPCWSTR, hTransaction: HANDLE) -> BOOL;
-    pub fn DeleteFileW(lpFileName: LPCWSTR) -> BOOL;
     pub fn DeleteProcThreadAttributeList(lpAttributeList: LPPROC_THREAD_ATTRIBUTE_LIST);
     pub fn DeleteTimerQueue(TimerQueue: HANDLE) -> BOOL;
     pub fn DeleteTimerQueueEx(TimerQueue: HANDLE, CompletionEvent: HANDLE) -> BOOL;
@@ -406,7 +381,6 @@ extern "system" {
     #[cfg(target_arch = "x86_64")]
     pub fn DeleteUmsThreadContext(UmsThread: PUMS_CONTEXT) -> BOOL;
     pub fn DeleteVolumeMountPointA(lpszVolumeMountPoint: LPCSTR) -> BOOL;
-    pub fn DeleteVolumeMountPointW(lpszVolumeMountPoint: LPCWSTR) -> BOOL;
     #[cfg(target_arch = "x86_64")]
     pub fn DequeueUmsCompletionListItems(
         UmsCompletionList: PUMS_COMPLETION_LIST, WaitTimeOut: DWORD,
@@ -573,9 +547,6 @@ extern "system" {
     pub fn FileTimeToDosDateTime(
         lpFileTime: *const FILETIME, lpFatDate: LPWORD, lpFatTime: LPWORD,
     ) -> BOOL;
-    pub fn FileTimeToLocalFileTime(
-        lpFileTime: *const FILETIME, lpLocalFileTime: LPFILETIME,
-    ) -> BOOL;
     pub fn FileTimeToSystemTime(
         lpFileTime: *const FILETIME, lpSystemTime: LPSYSTEMTIME,
     ) -> BOOL;
@@ -594,28 +565,9 @@ extern "system" {
     pub fn FindAtomA(lpString: LPCSTR) -> ATOM;
     pub fn FindAtomW(lpString: LPCWSTR) -> ATOM;
     pub fn FindClose(hFindFile: HANDLE) -> BOOL;
-    pub fn FindCloseChangeNotification(hChangeHandle: HANDLE) -> BOOL;
-    pub fn FindFirstChangeNotificationA(
-        lpPathName: LPCSTR, bWatchSubtree: BOOL, dwNotifyFilter: DWORD,
-    ) -> HANDLE;
-    pub fn FindFirstChangeNotificationW(
-        lpPathName: LPCWSTR, bWatchSubtree: BOOL, dwNotifyFilter: DWORD,
-    ) -> HANDLE;
-    pub fn FindFirstFileA(lpFileName: LPCSTR, lpFindFileData: LPWIN32_FIND_DATAA) -> HANDLE;
-    pub fn FindFirstFileExA(
-        lpFileName: LPCSTR, fInfoLevelId: FINDEX_INFO_LEVELS, lpFindFileData: LPVOID,
-        fSearchOp: FINDEX_SEARCH_OPS, lpSearchFilter: LPVOID, dwAdditionalFlags: DWORD,
-    ) -> HANDLE;
-    pub fn FindFirstFileExW(
-        lpFileName: LPCWSTR, fInfoLevelId: FINDEX_INFO_LEVELS, lpFindFileData: LPVOID,
-        fSearchOp: FINDEX_SEARCH_OPS, lpSearchFilter: LPVOID, dwAdditionalFlags: DWORD,
-    ) -> HANDLE;
     pub fn FindFirstFileNameTransactedW(
         lpFileName: LPCWSTR, dwFlags: DWORD, StringLength: LPDWORD, LinkName: PWSTR,
         hTransaction: HANDLE,
-    ) -> HANDLE;
-    pub fn FindFirstFileNameW(
-        lpFileName: LPCWSTR, dwFlags: DWORD, StringLength: LPDWORD, LinkName: PWSTR,
     ) -> HANDLE;
     pub fn FindFirstFileTransactedA(
         lpFileName: LPCSTR, fInfoLevelId: FINDEX_INFO_LEVELS, lpFindFileData: LPVOID,
@@ -627,14 +579,9 @@ extern "system" {
         fSearchOp: FINDEX_SEARCH_OPS, lpSearchFilter: LPVOID, dwAdditionalFlags: DWORD,
         hTransaction: HANDLE,
     ) -> HANDLE;
-    pub fn FindFirstFileW(lpFileName: LPCWSTR, lpFindFileData: LPWIN32_FIND_DATAW) -> HANDLE;
     pub fn FindFirstStreamTransactedW(
         lpFileName: LPCWSTR, InfoLevel: STREAM_INFO_LEVELS, lpFindStreamData: LPVOID,
         dwFlags: DWORD, hTransaction: HANDLE,
-    ) -> HANDLE;
-    pub fn FindFirstStreamW(
-        lpFileName: LPCWSTR, InfoLevel: STREAM_INFO_LEVELS, lpFindStreamData: LPVOID,
-        dwFlags: DWORD,
     ) -> HANDLE;
     pub fn FindFirstVolumeA(lpszVolumeName: LPSTR, cchBufferLength: DWORD) -> HANDLE;
     pub fn FindFirstVolumeMountPointA(
@@ -643,7 +590,6 @@ extern "system" {
     pub fn FindFirstVolumeMountPointW(
         lpszRootPathName: LPCWSTR, lpszVolumeMountPoint: LPWSTR, cchBufferLength: DWORD,
     ) -> HANDLE;
-    pub fn FindFirstVolumeW(lpszVolumeName: LPWSTR, cchBufferLength: DWORD) -> HANDLE;
     pub fn FindNLSString(
         Locale: LCID, dwFindNLSStringFlags: DWORD, lpStringSource: LPCWSTR, cchSource: c_int,
         lpStringValue: LPCWSTR, cchValue: c_int, pcchFound: LPINT,
@@ -653,11 +599,6 @@ extern "system" {
         cchSource: c_int, lpStringValue: LPCWSTR, cchValue: c_int, pcchFound: LPINT,
         lpVersionInformation: LPNLSVERSIONINFO, lpReserved: LPVOID, sortHandle: LPARAM,
     ) -> c_int;
-    pub fn FindNextChangeNotification(hChangeHandle: HANDLE) -> BOOL;
-    pub fn FindNextFileA(hFindFile: HANDLE, lpFindFileData: LPWIN32_FIND_DATAA) -> BOOL;
-    pub fn FindNextFileNameW(hFindStream: HANDLE, StringLength: LPDWORD, LinkName: PWSTR) -> BOOL;
-    pub fn FindNextFileW(hFindFile: HANDLE, lpFindFileData: LPWIN32_FIND_DATAW) -> BOOL;
-    pub fn FindNextStreamW(hFindStream: HANDLE, lpFindStreamData: LPVOID) -> BOOL;
     pub fn FindNextVolumeA(
         hFindVolume: HANDLE, lpszVolumeName: LPSTR, cchBufferLength: DWORD,
     ) -> BOOL;
@@ -666,9 +607,6 @@ extern "system" {
     ) -> BOOL;
     pub fn FindNextVolumeMountPointW(
         hFindVolumeMountPoint: HANDLE, lpszVolumeMountPoint: LPWSTR, cchBufferLength: DWORD,
-    ) -> BOOL;
-    pub fn FindNextVolumeW(
-        hFindVolume: HANDLE, lpszVolumeName: LPWSTR, cchBufferLength: DWORD,
     ) -> BOOL;
     // pub fn FindPackagesByPackageFamily();
     pub fn FindResourceA(hModule: HMODULE, lpName: LPCSTR, lpType: LPCSTR) -> HRSRC;
@@ -683,13 +621,11 @@ extern "system" {
         dwFindStringOrdinalFlags: DWORD, lpStringSource: LPCWSTR, cchSource: c_int,
         lpStringValue: LPCWSTR, cchValue: c_int, bIgnoreCase: BOOL,
     ) -> c_int;
-    pub fn FindVolumeClose(hFindVolume: HANDLE) -> BOOL;
     pub fn FindVolumeMountPointClose(hFindVolumeMountPoint: HANDLE) -> BOOL;
     pub fn FlsAlloc(lpCallback: PFLS_CALLBACK_FUNCTION) -> DWORD;
     pub fn FlsFree(dwFlsIndex: DWORD) -> BOOL;
     pub fn FlsGetValue(dwFlsIndex: DWORD) -> PVOID;
     pub fn FlsSetValue(dwFlsIndex: DWORD, lpFlsData: PVOID) -> BOOL;
-    pub fn FlushFileBuffers(hFile: HANDLE) -> BOOL;
     pub fn FlushInstructionCache(hProcess: HANDLE, lpBaseAddress: LPCVOID, dwSize: SIZE_T) -> BOOL;
     pub fn FlushProcessWriteBuffers();
     pub fn FlushViewOfFile(lpBaseAddress: LPCVOID, dwNumberOfBytesToFlush: SIZE_T) -> BOOL;
@@ -767,14 +703,12 @@ extern "system" {
     pub fn GetCommTimeouts(hFile: HANDLE, lpCommTimeouts: LPCOMMTIMEOUTS) -> BOOL;
     pub fn GetCommandLineA() -> LPSTR;
     pub fn GetCommandLineW() -> LPWSTR;
-    pub fn GetCompressedFileSizeA(lpFileName: LPCSTR, lpFileSizeHigh: LPDWORD) -> DWORD;
     pub fn GetCompressedFileSizeTransactedA(
         lpFileName: LPCSTR, lpFileSizeHigh: LPDWORD, hTransaction: HANDLE,
     ) -> DWORD;
     pub fn GetCompressedFileSizeTransactedW(
         lpFileName: LPCWSTR, lpFileSizeHigh: LPDWORD, hTransaction: HANDLE,
     );
-    pub fn GetCompressedFileSizeW(lpFileName: LPCWSTR, lpFileSizeHigh: LPDWORD) -> DWORD;
     pub fn GetComputerNameA(lpBuffer: LPSTR, nSize: LPDWORD) -> BOOL;
     pub fn GetComputerNameExA(
         NameType: COMPUTER_NAME_FORMAT, lpBuffer: LPSTR, nSize: LPDWORD,
@@ -824,26 +758,8 @@ extern "system" {
     pub fn GetDefaultCommConfigA(lpszName: LPCSTR, lpCC: LPCOMMCONFIG, lpdwSize: LPDWORD) -> BOOL;
     pub fn GetDefaultCommConfigW(lpszName: LPCWSTR, lpCC: LPCOMMCONFIG, lpdwSize: LPDWORD) -> BOOL;
     pub fn GetDevicePowerState(hDevice: HANDLE, pfOn: *mut BOOL) -> BOOL;
-    pub fn GetDiskFreeSpaceA(
-        lpRootPathName: LPCSTR, lpSectorsPerCluster: LPDWORD, lpBytesPerSector: LPDWORD,
-        lpNumberOfFreeClusters: LPDWORD, lpTotalNumberOfClusters: LPDWORD,
-    ) -> BOOL;
-    pub fn GetDiskFreeSpaceExA(
-        lpDirectoryName: LPCSTR, lpFreeBytesAvailableToCaller: PULARGE_INTEGER,
-        lpTotalNumberOfBytes: PULARGE_INTEGER, lpTotalNumberOfFreeBytes: PULARGE_INTEGER,
-    ) -> BOOL;
-    pub fn GetDiskFreeSpaceExW(
-        lpDirectoryName: LPCWSTR, lpFreeBytesAvailableToCaller: PULARGE_INTEGER,
-        lpTotalNumberOfBytes: PULARGE_INTEGER, lpTotalNumberOfFreeBytes: PULARGE_INTEGER,
-    ) -> BOOL;
-    pub fn GetDiskFreeSpaceW(
-        lpRootPathName: LPCWSTR, lpSectorsPerCluster: LPDWORD, lpBytesPerSector: LPDWORD,
-        lpNumberOfFreeClusters: LPDWORD, lpTotalNumberOfClusters: LPDWORD,
-    ) -> BOOL;
     pub fn GetDllDirectoryA(nBufferLength: DWORD, lpBuffer: LPSTR) -> DWORD;
     pub fn GetDllDirectoryW(nBufferLength: DWORD, lpBuffer: LPWSTR) -> DWORD;
-    pub fn GetDriveTypeA(lpRootPathName: LPCSTR) -> UINT;
-    pub fn GetDriveTypeW(lpRootPathName: LPCWSTR) -> UINT;
     pub fn GetDurationFormat(
         Locale: LCID, dwFlags: DWORD, lpDuration: *const SYSTEMTIME, ullDuration: ULONGLONG,
         lpFormat: LPCWSTR, lpDurationStr: LPWSTR, cchDuration: c_int,
@@ -862,13 +778,6 @@ extern "system" {
     pub fn GetEnvironmentVariableA(lpName: LPCSTR, lpBuffer: LPSTR, nSize: DWORD) -> DWORD;
     pub fn GetEnvironmentVariableW(lpName: LPCWSTR, lpBuffer: LPWSTR, nSize: DWORD) -> DWORD;
     // pub fn GetEraNameCountedString();
-    pub fn GetFileAttributesA(lpFileName: LPCSTR) -> DWORD;
-    pub fn GetFileAttributesExA(
-        lpFileName: LPCSTR, fInfoLevelId: GET_FILEEX_INFO_LEVELS, lpFileInformation: LPVOID,
-    ) -> BOOL;
-    pub fn GetFileAttributesExW(
-        lpFileName: LPCWSTR, fInfoLevelId: GET_FILEEX_INFO_LEVELS, lpFileInformation: LPVOID,
-    ) -> BOOL;
     pub fn GetFileAttributesTransactedA(
         lpFileName: LPCSTR, fInfoLevelId: GET_FILEEX_INFO_LEVELS, lpFileInformation: LPVOID,
         hTransaction: HANDLE,
@@ -877,13 +786,9 @@ extern "system" {
         lpFileName: LPCWSTR, fInfoLevelId: GET_FILEEX_INFO_LEVELS, lpFileInformation: LPVOID,
         hTransaction: HANDLE,
     ) -> BOOL;
-    pub fn GetFileAttributesW(lpFileName: LPCWSTR) -> DWORD;
     pub fn GetFileBandwidthReservation(
         hFile: HANDLE, lpPeriodMilliseconds: LPDWORD, lpBytesPerPeriod: LPDWORD,
         pDiscardable: LPBOOL, lpTransferSize: LPDWORD, lpNumOutstandingRequests: LPDWORD,
-    ) -> BOOL;
-    pub fn GetFileInformationByHandle(
-        hFile: HANDLE, lpFileInformation: LPBY_HANDLE_FILE_INFORMATION,
     ) -> BOOL;
     pub fn GetFileInformationByHandleEx(
         hFile: HANDLE, FileInformationClass: FILE_INFO_BY_HANDLE_CLASS, lpFileInformation: LPVOID,
@@ -897,19 +802,6 @@ extern "system" {
         dwFlags: DWORD, pcwszFilePath: PCWSTR, pwszLanguage: PWSTR, pcchLanguage: PULONG,
         pwszFileMUIPath: PWSTR, pcchFileMUIPath: PULONG, pululEnumerator: PULONGLONG,
     ) -> BOOL;
-    pub fn GetFileSize(hFile: HANDLE, lpFileSizeHigh: LPDWORD) -> DWORD;
-    pub fn GetFileSizeEx(hFile: HANDLE, lpFileSize: PLARGE_INTEGER) -> BOOL;
-    pub fn GetFileTime(
-        hFile: HANDLE, lpCreationTime: LPFILETIME, lpLastAccessTime: LPFILETIME,
-        lpLastWriteTime: LPFILETIME,
-    ) -> BOOL;
-    pub fn GetFileType(hFile: HANDLE) -> DWORD;
-    pub fn GetFinalPathNameByHandleA(
-        hFile: HANDLE, lpszFilePath: LPSTR, cchFilePath: DWORD, dwFlags: DWORD,
-    ) -> DWORD;
-    pub fn GetFinalPathNameByHandleW(
-        hFile: HANDLE, lpszFilePath: LPWSTR, cchFilePath: DWORD, dwFlags: DWORD,
-    ) -> DWORD;
     pub fn GetFirmwareEnvironmentVariableA(
         lpName: LPCSTR, lpGuid: LPCSTR, pBuffer: PVOID, nSize: DWORD,
     ) -> DWORD;
@@ -923,9 +815,6 @@ extern "system" {
         lpName: LPCWSTR, lpGuid: LPCWSTR, pBuffer: PVOID, nSize: DWORD,
     ) -> DWORD;
     pub fn GetFirmwareType(FirmwareType: PFIRMWARE_TYPE) -> BOOL;
-    pub fn GetFullPathNameA(
-        lpFileName: LPCSTR, nBufferLength: DWORD, lpBuffer: LPSTR, lpFilePart: *mut LPSTR,
-    ) -> DWORD;
     pub fn GetFullPathNameTransactedA(
         lpFileName: LPCSTR, nBufferLength: DWORD, lpBuffer: LPSTR, lpFilePart: *mut LPSTR,
         hTransaction: HANDLE,
@@ -934,9 +823,6 @@ extern "system" {
         lpFileName: LPCWSTR, nBufferLength: DWORD, lpBuffer: LPWSTR, lpFilePart: *mut LPWSTR,
         hTransaction: HANDLE,
     );
-    pub fn GetFullPathNameW(
-        lpFileName: LPCWSTR, nBufferLength: DWORD, lpBuffer: LPWSTR, lpFilePart: *mut LPWSTR,
-    ) -> DWORD;
     pub fn GetGeoInfoA(
         Location: GEOID, GeoType: GEOTYPE, lpGeoData: LPSTR, cchData: c_int, LangId: LANGID,
     ) -> c_int;
@@ -955,8 +841,6 @@ extern "system" {
         Locale: LCID, LCType: LCTYPE, lpLCData: LPWSTR, cchData: c_int,
     ) -> c_int;
     pub fn GetLogicalDriveStringsA(nBufferLength: DWORD, lpBuffer: LPSTR) -> DWORD;
-    pub fn GetLogicalDriveStringsW(nBufferLength: DWORD, lpBuffer: LPWSTR) -> DWORD;
-    pub fn GetLogicalDrives() -> DWORD;
     pub fn GetLogicalProcessorInformation(
         Buffer: PSYSTEM_LOGICAL_PROCESSOR_INFORMATION, ReturnedLength: PDWORD,
     ) -> BOOL;
@@ -965,15 +849,11 @@ extern "system" {
         Buffer: PSYSTEM_LOGICAL_PROCESSOR_INFORMATION,
         ReturnedLength: PDWORD,
     ) -> BOOL;
-    pub fn GetLongPathNameA(lpszShortPath: LPCSTR, lpszLongPath: LPSTR, cchBuffer: DWORD) -> DWORD;
     pub fn GetLongPathNameTransactedA(
         lpszShortPath: LPCSTR, lpszLongPath: LPSTR, cchBuffer: DWORD, hTransaction: HANDLE,
     ) -> DWORD;
     pub fn GetLongPathNameTransactedW(
         lpszShortPath: LPCWSTR, lpszLongPath: LPWSTR, cchBuffer: DWORD, hTransaction: HANDLE,
-    ) -> DWORD;
-    pub fn GetLongPathNameW(
-        lpszShortPath: LPCWSTR, lpszLongPath: LPWSTR, cchBuffer: DWORD,
     ) -> DWORD;
     pub fn GetMailslotInfo(
         hMailslot: HANDLE, lpMaxMessageSize: LPDWORD, lpNextSize: LPDWORD, lpMessageCount: LPDWORD,
@@ -1161,9 +1041,6 @@ extern "system" {
     pub fn GetShortPathNameA(
         lpszLongPath: LPCSTR, lpszShortPath: LPSTR, cchBuffer: DWORD,
     ) -> DWORD;
-    pub fn GetShortPathNameW(
-        lpszLongPath: LPCWSTR, lpszShortPath: LPWSTR, cchBuffer: DWORD,
-    ) -> DWORD;
     // pub fn GetStagedPackagePathByFullName();
     pub fn GetStartupInfoA(lpStartupInfo: LPSTARTUPINFOA);
     pub fn GetStartupInfoW(lpStartupInfo: LPSTARTUPINFOW);
@@ -1227,14 +1104,6 @@ extern "system" {
         lpdwOffsetLow: LPDWORD, lpdwOffsetHigh: LPDWORD
     ) -> DWORD;
     pub fn GetTapeStatus(hDevice: HANDLE) -> DWORD;
-    pub fn GetTempFileNameA(
-        lpPathName: LPCSTR, lpPrefixString: LPCSTR, uUnique: UINT, lpTempFileName: LPSTR,
-    ) -> UINT;
-    pub fn GetTempFileNameW(
-        lpPathName: LPCWSTR, lpPrefixString: LPCWSTR, uUnique: UINT, lpTempFileName: LPWSTR,
-    ) -> UINT;
-    pub fn GetTempPathA(nBufferLength: DWORD, lpBuffer: LPSTR) -> DWORD;
-    pub fn GetTempPathW(nBufferLength: DWORD, lpBuffer: LPWSTR) -> DWORD;
     pub fn GetThreadContext(hThread: HANDLE, lpContext: LPCONTEXT) -> BOOL;
     pub fn GetThreadGroupAffinity(hThread: HANDLE, GroupAffinity: PGROUP_AFFINITY) -> BOOL;
     pub fn GetThreadIOPendingFlag(hThread: HANDLE, lpIOIsPending: PBOOL) -> BOOL;
@@ -1299,32 +1168,11 @@ extern "system" {
     pub fn GetVersion() -> DWORD;
     pub fn GetVersionExA(lpVersionInformation: LPOSVERSIONINFOA) -> BOOL;
     pub fn GetVersionExW(lpVersionInformation: LPOSVERSIONINFOW) -> BOOL;
-    pub fn GetVolumeInformationA(
-        lpRootPathName: LPCSTR, lpVolumeNameBuffer: LPSTR, nVolumeNameSize: DWORD,
-        lpVolumeSerialNumber: LPDWORD, lpMaximumComponentLength: LPDWORD,
-        lpFileSystemFlags: LPDWORD, lpFileSystemNameBuffer: LPSTR, nFileSystemNameSize: DWORD,
-    ) -> BOOL;
-    pub fn GetVolumeInformationByHandleW(
-        hFile: HANDLE, lpVolumeNameBuffer: LPWSTR, nVolumeNameSize: DWORD,
-        lpVolumeSerialNumber: LPDWORD, lpMaximumComponentLength: LPDWORD,
-        lpFileSystemFlags: LPDWORD, lpFileSystemNameBuffer: LPWSTR, nFileSystemNameSize: DWORD,
-    ) -> BOOL;
-    pub fn GetVolumeInformationW(
-        lpRootPathName: LPCWSTR, lpVolumeNameBuffer: LPWSTR, nVolumeNameSize: DWORD,
-        lpVolumeSerialNumber: LPDWORD, lpMaximumComponentLength: LPDWORD,
-        lpFileSystemFlags: LPDWORD, lpFileSystemNameBuffer: LPWSTR, nFileSystemNameSize: DWORD,
-    ) -> BOOL;
     pub fn GetVolumeNameForVolumeMountPointA(
         lpszVolumeMountPoint: LPCSTR, lpszVolumeName: LPSTR, cchBufferLength: DWORD,
     ) -> BOOL;
-    pub fn GetVolumeNameForVolumeMountPointW(
-        lpszVolumeMountPoint: LPCWSTR, lpszVolumeName: LPWSTR, cchBufferLength: DWORD,
-    ) -> BOOL;
     pub fn GetVolumePathNameA(
         lpszFileName: LPCSTR, lpszVolumePathName: LPSTR, cchBufferLength: DWORD,
-    ) -> BOOL;
-    pub fn GetVolumePathNameW(
-        lpszFileName: LPCWSTR, lpszVolumePathName: LPWSTR, cchBufferLength: DWORD,
     ) -> BOOL;
     pub fn GetVolumePathNamesForVolumeNameA(
         lpszVolumeName: LPCSTR, lpszVolumePathNames: LPCH, cchBufferLength: DWORD,
@@ -1551,9 +1399,6 @@ extern "system" {
     // pub fn LoadStringBaseW();
     pub fn LocalAlloc(uFlags: UINT, uBytes: SIZE_T) -> HLOCAL;
     pub fn LocalCompact(uMinFree: UINT) -> SIZE_T;
-    pub fn LocalFileTimeToFileTime(
-        lpLocalFileTime: *const FILETIME, lpFileTime: LPFILETIME,
-    ) -> BOOL;
     pub fn LocalFlags(hMem: HLOCAL) -> UINT;
     pub fn LocalFree(hMem: HLOCAL) -> HLOCAL;
     pub fn LocalHandle(pMem: LPCVOID) -> HLOCAL;
@@ -1565,14 +1410,6 @@ extern "system" {
     pub fn LocaleNameToLCID(lpName: LPCWSTR, dwFlags: DWORD) -> LCID;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn LocateXStateFeature(Context: PCONTEXT, FeatureId: DWORD, Length: PDWORD) -> PVOID;
-    pub fn LockFile(
-        hFile: HANDLE, dwFileOffsetLow: DWORD, dwFileOffsetHigh: DWORD,
-        nNumberOfBytesToLockLow: DWORD, nNumberOfBytesToLockHigh: DWORD,
-    ) -> BOOL;
-    pub fn LockFileEx(
-        hFile: HANDLE, dwFlags: DWORD, dwReserved: DWORD, nNumberOfBytesToLockLow: DWORD,
-        nNumberOfBytesToLockHigh: DWORD, lpOverlapped: LPOVERLAPPED,
-    ) -> BOOL;
     pub fn LockResource(hResData: HGLOBAL) -> LPVOID;
     pub fn MapUserPhysicalPages(
         VirtualAddress: PVOID, NumberOfPages: ULONG_PTR, PageArray: PULONG_PTR,
@@ -1731,7 +1568,6 @@ extern "system" {
     ) -> BOOL;
     pub fn QueryDepthSList(ListHead: PSLIST_HEADER) -> USHORT;
     pub fn QueryDosDeviceA(lpDeviceName: LPCSTR, lpTargetPath: LPSTR, ucchMax: DWORD) -> DWORD;
-    pub fn QueryDosDeviceW(lpDeviceName: LPCWSTR, lpTargetPath: LPWSTR, ucchMax: DWORD) -> DWORD;
     pub fn QueryFullProcessImageNameA(
         hProcess: HANDLE, dwFlags: DWORD, lpExeName: LPSTR, lpdwSize: PDWORD,
     ) -> BOOL;
@@ -1779,18 +1615,6 @@ extern "system" {
         dwNotifyFilter: DWORD, lpBytesReturned: LPDWORD, lpOverlapped: LPOVERLAPPED,
         lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
     ) -> BOOL;
-    pub fn ReadFile(
-        hFile: HANDLE, lpBuffer: LPVOID, nNumberOfBytesToRead: DWORD, lpNumberOfBytesRead: LPDWORD,
-        lpOverlapped: LPOVERLAPPED,
-    ) -> BOOL;
-    pub fn ReadFileEx(
-        hFile: HANDLE, lpBuffer: LPVOID, nNumberOfBytesToRead: DWORD, lpOverlapped: LPOVERLAPPED,
-        lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
-    ) -> BOOL;
-    pub fn ReadFileScatter(
-        hFile: HANDLE, aSegmentArray: *mut FILE_SEGMENT_ELEMENT, nNumberOfBytesToRead: DWORD,
-        lpReserved: LPDWORD, lpOverlapped: LPOVERLAPPED,
-    ) -> BOOL;
     pub fn ReadProcessMemory(
         hProcess: HANDLE, lpBaseAddress: LPCVOID, lpBuffer: LPVOID, nSize: SIZE_T,
         lpNumberOfBytesRead: *mut SIZE_T,
@@ -1819,10 +1643,8 @@ extern "system" {
     pub fn ReleaseSemaphoreWhenCallbackReturns(
         pci: PTP_CALLBACK_INSTANCE, sem: HANDLE, crel: DWORD,
     );
-    pub fn RemoveDirectoryA(lpPathName: LPCSTR) -> BOOL;
     pub fn RemoveDirectoryTransactedA(lpPathName: LPCSTR, hTransaction: HANDLE) -> BOOL;
     pub fn RemoveDirectoryTransactedW(lpPathName: LPCWSTR, hTransaction: HANDLE) -> BOOL;
-    pub fn RemoveDirectoryW(lpPathName: LPCWSTR) -> BOOL;
     pub fn RemoveDllDirectory(Cookie: DLL_DIRECTORY_COOKIE) -> BOOL;
     // pub fn RemoveLocalAlternateComputerNameA();
     // pub fn RemoveLocalAlternateComputerNameW();
@@ -1952,48 +1774,24 @@ extern "system" {
     pub fn SetDynamicTimeZoneInformation(
         lpTimeZoneInformation: *const DYNAMIC_TIME_ZONE_INFORMATION,
     ) -> BOOL;
-    pub fn SetEndOfFile(hFile: HANDLE) -> BOOL;
     pub fn SetEnvironmentStringsA(NewEnvironment: LPCH) -> BOOL;
     pub fn SetEnvironmentStringsW(NewEnvironment: LPWCH) -> BOOL;
     pub fn SetEnvironmentVariableA(lpName: LPCSTR, lpValue: LPCSTR) -> BOOL;
     pub fn SetEnvironmentVariableW(lpName: LPCWSTR, lpValue: LPCWSTR) -> BOOL;
     pub fn SetEventWhenCallbackReturns(pci: PTP_CALLBACK_INSTANCE, evt: HANDLE);
-    pub fn SetFileApisToANSI();
-    pub fn SetFileApisToOEM();
-    pub fn SetFileAttributesA(lpFileName: LPCSTR, dwFileAttributes: DWORD) -> BOOL;
     pub fn SetFileAttributesTransactedA(
         lpFileName: LPCSTR, dwFileAttributes: DWORD, hTransaction: HANDLE,
     ) -> BOOL;
     pub fn SetFileAttributesTransactedW(
         lpFileName: LPCWSTR, dwFileAttributes: DWORD, hTransaction: HANDLE,
     ) -> BOOL;
-    pub fn SetFileAttributesW(lpFileName: LPCWSTR, dwFileAttributes: DWORD) -> BOOL;
     pub fn SetFileBandwidthReservation(
         hFile: HANDLE, nPeriodMilliseconds: DWORD, nBytesPerPeriod: DWORD, bDiscardable: BOOL,
         lpTransferSize: LPDWORD, lpNumOutstandingRequests: LPDWORD,
     ) -> BOOL;
     pub fn SetFileCompletionNotificationModes(FileHandle: HANDLE, Flags: UCHAR) -> BOOL;
-    pub fn SetFileInformationByHandle(
-        hFile: HANDLE, FileInformationClass: FILE_INFO_BY_HANDLE_CLASS, lpFileInformation: LPVOID,
-        dwBufferSize: DWORD,
-    ) -> BOOL;
-    pub fn SetFileIoOverlappedRange(
-        FileHandle: HANDLE, OverlappedRangeStart: PUCHAR, Length: ULONG,
-    ) -> BOOL;
-    pub fn SetFilePointer(
-        hFile: HANDLE, lDistanceToMove: LONG, lpDistanceToMoveHigh: PLONG, dwMoveMethod: DWORD,
-    ) -> DWORD;
-    pub fn SetFilePointerEx(
-        hFile: HANDLE, liDistanceToMove: LARGE_INTEGER, lpNewFilePointer: PLARGE_INTEGER,
-        dwMoveMethod: DWORD,
-    ) -> BOOL;
     pub fn SetFileShortNameA(hFile: HANDLE, lpShortName: LPCSTR) -> BOOL;
     pub fn SetFileShortNameW(hFile: HANDLE, lpShortName: LPCWSTR) -> BOOL;
-    pub fn SetFileTime(
-        hFile: HANDLE, lpCreationTime: *const FILETIME, lpLastAccessTime: *const FILETIME,
-        lpLastWriteTime: *const FILETIME,
-    ) -> BOOL;
-    pub fn SetFileValidData(hFile: HANDLE, ValidDataLength: LONGLONG) -> BOOL;
     pub fn SetFirmwareEnvironmentVariableA(
         lpName: LPCSTR, lpGuid: LPCSTR, pValue: PVOID, nSize: DWORD,
     ) -> BOOL;
@@ -2164,14 +1962,6 @@ extern "system" {
     ) -> BOOL;
     #[cfg(target_arch = "x86_64")]
     pub fn UmsThreadYield(SchedulerParam: PVOID) -> BOOL;
-    pub fn UnlockFile(
-        hFile: HANDLE, dwFileOffsetLow: DWORD, dwFileOffsetHigh: DWORD,
-        nNumberOfBytesToUnlockLow: DWORD, nNumberOfBytesToUnlockHigh: DWORD,
-    ) -> BOOL;
-    pub fn UnlockFileEx(
-        hFile: HANDLE, dwReserved: DWORD, nNumberOfBytesToUnlockLow: DWORD,
-        nNumberOfBytesToUnlockHigh: DWORD, lpOverlapped: LPOVERLAPPED,
-    ) -> BOOL;
     pub fn UnmapViewOfFile(lpBaseAddress: LPCVOID) -> BOOL;
     pub fn UnregisterApplicationRecoveryCallback() -> HRESULT;
     pub fn UnregisterApplicationRestart() -> HRESULT;
@@ -2277,18 +2067,6 @@ extern "system" {
     pub fn Wow64RevertWow64FsRedirection(OlValue: PVOID) -> BOOL;
     pub fn Wow64SetThreadContext(hThread: HANDLE, lpContext: *const WOW64_CONTEXT) -> BOOL;
     pub fn Wow64SuspendThread(hThread: HANDLE) -> DWORD;
-    pub fn WriteFile(
-        hFile: HANDLE, lpBuffer: LPCVOID, nNumberOfBytesToWrite: DWORD,
-        lpNumberOfBytesWritten: LPDWORD, lpOverlapped: LPOVERLAPPED,
-    ) -> BOOL;
-    pub fn WriteFileEx(
-        hFile: HANDLE, lpBuffer: LPCVOID, nNumberOfBytesToWrite: DWORD, lpOverlapped: LPOVERLAPPED,
-        lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
-    ) -> BOOL;
-    pub fn WriteFileGather(
-        hFile: HANDLE, aSegmentArray: *mut FILE_SEGMENT_ELEMENT, nNumberOfBytesToWrite: DWORD,
-        lpReserved: LPDWORD, lpOverlapped: LPOVERLAPPED,
-    ) -> BOOL;
     pub fn WritePrivateProfileSectionA(
         lpAppName: LPCSTR, lpString: LPCSTR, lpFileName: LPCSTR,
     ) -> BOOL;

--- a/src/um/fileapi.rs
+++ b/src/um/fileapi.rs
@@ -5,9 +5,21 @@
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
 //! ApiSet Contract for api-ms-win-core-file-l1
-use shared::minwindef::{BOOL, DWORD, FILETIME, UCHAR, ULONG, WORD};
-use um::minwinbase::LPSECURITY_ATTRIBUTES;
-use um::winnt::{BOOLEAN, CCHAR, FILE_ID_128, HANDLE, LARGE_INTEGER, ULONGLONG, WCHAR};
+use shared::minwindef::{
+    BOOL, DWORD, FILETIME, LPCVOID, LPDWORD, LPFILETIME, LPVOID, PDWORD, PUCHAR, UCHAR, UINT, ULONG,
+    WORD
+};
+use um::minwinbase::{
+    FILE_INFO_BY_HANDLE_CLASS, FINDEX_INFO_LEVELS, FINDEX_SEARCH_OPS, GET_FILEEX_INFO_LEVELS,
+    LPOVERLAPPED, LPOVERLAPPED_COMPLETION_ROUTINE, LPSECURITY_ATTRIBUTES, LPWIN32_FIND_DATAA,
+    LPWIN32_FIND_DATAW
+};
+use um::winbase::STREAM_INFO_LEVELS;
+use um::winnt::{
+    BOOLEAN, CCHAR, FILE_ID_128, FILE_SEGMENT_ELEMENT, HANDLE, LARGE_INTEGER, LONG, LONGLONG,
+    LPCSTR, LPCWSTR, LPSTR, LPWCH, LPWSTR, PLARGE_INTEGER, PLONG, PULARGE_INTEGER, PWSTR, ULONGLONG,
+    WCHAR
+};
 pub const CREATE_NEW: DWORD = 1;
 pub const CREATE_ALWAYS: DWORD = 2;
 pub const OPEN_EXISTING: DWORD = 3;
@@ -157,3 +169,464 @@ STRUCT!{struct FILE_ID_INFO {
     VolumeSerialNumber: ULONGLONG,
     FileId: FILE_ID_128,
 }}
+extern "system" {
+    pub fn CompareFileTime(
+        lpFileTime1: *const FILETIME,
+        lpFileTime2: *const FILETIME
+    ) -> LONG;
+    pub fn CreateDirectoryA(
+        lpPathName: LPCSTR,
+        lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+    ) -> BOOL;
+    pub fn CreateDirectoryW(
+        lpPathName: LPCWSTR,
+        lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+    ) -> BOOL;
+    pub fn CreateFileA(
+        lpFileName: LPCSTR,
+        dwDesiredAccess: DWORD,
+        dwShareMode: DWORD,
+        lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+        dwCreationDisposition: DWORD,
+        dwFlagsAndAttributes: DWORD,
+        hTemplateFile: HANDLE,
+    ) -> HANDLE;
+    pub fn CreateFileW(
+        lpFileName: LPCWSTR,
+        dwDesiredAccess: DWORD,
+        dwShareMode: DWORD,
+        lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+        dwCreationDisposition: DWORD,
+        dwFlagsAndAttributes: DWORD,
+        hTemplateFile: HANDLE,
+    ) -> HANDLE;
+    pub fn DefineDosDeviceW(
+        dwFlags: DWORD,
+        lpDeviceName: LPCWSTR,
+        lpTargetPath: LPCWSTR
+    ) -> BOOL;
+    pub fn DeleteFileA(
+        lpFileName: LPCSTR
+    ) -> BOOL;
+    pub fn DeleteFileW(
+        lpFileName: LPCWSTR
+    ) -> BOOL;
+    pub fn DeleteVolumeMountPointW(
+        lpszVolumeMountPoint: LPCWSTR
+    ) -> BOOL;
+    pub fn FileTimeToLocalFileTime(
+        lpFileTime: *const FILETIME,
+        lpLocalFileTime: LPFILETIME,
+    ) -> BOOL;
+    pub fn FindCloseChangeNotification(
+        hChangeHandle: HANDLE
+    ) -> BOOL;
+    pub fn FindFirstChangeNotificationA(
+        lpPathName: LPCSTR,
+        bWatchSubtree: BOOL,
+        dwNotifyFilter: DWORD,
+    ) -> HANDLE;
+    pub fn FindFirstChangeNotificationW(
+        lpPathName: LPCWSTR,
+        bWatchSubtree: BOOL,
+        dwNotifyFilter: DWORD,
+    ) -> HANDLE;
+    pub fn FindFirstFileA(
+        lpFileName: LPCSTR,
+        lpFindFileData: LPWIN32_FIND_DATAA
+    ) -> HANDLE;
+    pub fn FindFirstFileW(
+        lpFileName: LPCWSTR,
+        lpFindFileData: LPWIN32_FIND_DATAW
+    ) -> HANDLE;
+    pub fn FindFirstFileExA(
+        lpFileName: LPCSTR,
+        fInfoLevelId: FINDEX_INFO_LEVELS,
+        lpFindFileData: LPVOID,
+        fSearchOp: FINDEX_SEARCH_OPS,
+        lpSearchFilter: LPVOID,
+        dwAdditionalFlags: DWORD,
+    ) -> HANDLE;
+    pub fn FindFirstFileExW(
+        lpFileName: LPCWSTR,
+        fInfoLevelId: FINDEX_INFO_LEVELS,
+        lpFindFileData: LPVOID,
+        fSearchOp: FINDEX_SEARCH_OPS,
+        lpSearchFilter: LPVOID,
+        dwAdditionalFlags: DWORD,
+    ) -> HANDLE;
+    pub fn FindFirstVolumeW(
+        lpszVolumeName: LPWSTR,
+        cchBufferLength: DWORD
+    ) -> HANDLE;
+    pub fn FindNextChangeNotification(
+        hChangeHandle: HANDLE
+    ) -> BOOL;
+    pub fn FindNextFileA(
+        hFindFile: HANDLE,
+        lpFindFileData: LPWIN32_FIND_DATAA
+    ) -> BOOL;
+    pub fn FindNextFileW(
+        hFindFile: HANDLE,
+        lpFindFileData: LPWIN32_FIND_DATAW
+    ) -> BOOL;
+    pub fn FindNextVolumeW(
+        hFindVolume: HANDLE,
+        lpszVolumeName: LPWSTR,
+        cchBufferLength: DWORD,
+    ) -> BOOL;
+    pub fn FindVolumeClose(
+        hFindVolume: HANDLE
+    ) -> BOOL;
+    pub fn FlushFileBuffers(
+        hFile: HANDLE
+    ) -> BOOL;
+    pub fn GetDiskFreeSpaceA(
+        lpRootPathName: LPCSTR,
+        lpSectorsPerCluster: LPDWORD,
+        lpBytesPerSector: LPDWORD,
+        lpNumberOfFreeClusters: LPDWORD,
+        lpTotalNumberOfClusters: LPDWORD,
+    ) -> BOOL;
+    pub fn GetDiskFreeSpaceW(
+        lpRootPathName: LPCWSTR,
+        lpSectorsPerCluster: LPDWORD,
+        lpBytesPerSector: LPDWORD,
+        lpNumberOfFreeClusters: LPDWORD,
+        lpTotalNumberOfClusters: LPDWORD,
+    ) -> BOOL;
+    pub fn GetDiskFreeSpaceExA(
+        lpDirectoryName: LPCSTR,
+        lpFreeBytesAvailableToCaller: PULARGE_INTEGER,
+        lpTotalNumberOfBytes: PULARGE_INTEGER,
+        lpTotalNumberOfFreeBytes: PULARGE_INTEGER,
+    ) -> BOOL;
+    pub fn GetDiskFreeSpaceExW(
+        lpDirectoryName: LPCWSTR,
+        lpFreeBytesAvailableToCaller: PULARGE_INTEGER,
+        lpTotalNumberOfBytes: PULARGE_INTEGER,
+        lpTotalNumberOfFreeBytes: PULARGE_INTEGER,
+    ) -> BOOL;
+    pub fn GetDriveTypeA(
+        lpRootPathName: LPCSTR
+    ) -> UINT;
+    pub fn GetDriveTypeW(
+        lpRootPathName: LPCWSTR
+    ) -> UINT;
+    pub fn GetFileAttributesA(
+        lpFileName: LPCSTR
+    ) -> DWORD;
+    pub fn GetFileAttributesW(
+        lpFileName: LPCWSTR
+    ) -> DWORD;
+    pub fn GetFileAttributesExA(
+        lpFileName: LPCSTR,
+        fInfoLevelId: GET_FILEEX_INFO_LEVELS,
+        lpFileInformation: LPVOID,
+    ) -> BOOL;
+    pub fn GetFileAttributesExW(
+        lpFileName: LPCWSTR,
+        fInfoLevelId: GET_FILEEX_INFO_LEVELS,
+        lpFileInformation: LPVOID,
+    ) -> BOOL;
+    pub fn GetFileInformationByHandle(
+        hFile: HANDLE,
+        lpFileInformation: LPBY_HANDLE_FILE_INFORMATION,
+    ) -> BOOL;
+    pub fn GetFileSize(
+        hFile: HANDLE,
+        lpFileSizeHigh: LPDWORD
+    ) -> DWORD;
+    pub fn GetFileSizeEx(
+        hFile: HANDLE,
+        lpFileSize: PLARGE_INTEGER
+    ) -> BOOL;
+    pub fn GetFileType(
+        hFile: HANDLE
+    ) -> DWORD;
+    pub fn GetFinalPathNameByHandleA(
+        hFile: HANDLE,
+        lpszFilePath: LPSTR,
+        cchFilePath: DWORD,
+        dwFlags: DWORD,
+    ) -> DWORD;
+    pub fn GetFinalPathNameByHandleW(
+        hFile: HANDLE,
+        lpszFilePath: LPWSTR,
+        cchFilePath: DWORD,
+        dwFlags: DWORD,
+    ) -> DWORD;
+    pub fn GetFileTime(
+        hFile: HANDLE,
+        lpCreationTime: LPFILETIME,
+        lpLastAccessTime: LPFILETIME,
+        lpLastWriteTime: LPFILETIME,
+    ) -> BOOL;
+    pub fn GetFullPathNameW(
+        lpFileName: LPCWSTR,
+        nBufferLength: DWORD,
+        lpBuffer: LPWSTR,
+        lpFilePart: *mut LPWSTR,
+    ) -> DWORD;
+    pub fn GetFullPathNameA(
+        lpFileName: LPCSTR,
+        nBufferLength: DWORD,
+        lpBuffer: LPSTR,
+        lpFilePart: *mut LPSTR,
+    ) -> DWORD;
+    pub fn GetLogicalDrives() -> DWORD;
+    pub fn GetLogicalDriveStringsW(
+        nBufferLength: DWORD,
+        lpBuffer: LPWSTR
+    ) -> DWORD;
+    pub fn GetLongPathNameA(
+        lpszShortPath: LPCSTR,
+        lpszLongPath: LPSTR,
+        cchBuffer: DWORD
+    ) -> DWORD;
+    pub fn GetLongPathNameW(
+        lpszShortPath: LPCWSTR,
+        lpszLongPath: LPWSTR,
+        cchBuffer: DWORD,
+    ) -> DWORD;
+    pub fn GetShortPathNameW(
+        lpszLongPath: LPCWSTR,
+        lpszShortPath: LPWSTR,
+        cchBuffer: DWORD,
+    ) -> DWORD;
+    pub fn GetTempFileNameW(
+        lpPathName: LPCWSTR,
+        lpPrefixString: LPCWSTR,
+        uUnique: UINT,
+        lpTempFileName: LPWSTR,
+    ) -> UINT;
+    pub fn GetVolumeInformationByHandleW(
+        hFile: HANDLE,
+        lpVolumeNameBuffer: LPWSTR,
+        nVolumeNameSize: DWORD,
+        lpVolumeSerialNumber: LPDWORD,
+        lpMaximumComponentLength: LPDWORD,
+        lpFileSystemFlags: LPDWORD,
+        lpFileSystemNameBuffer: LPWSTR,
+        nFileSystemNameSize: DWORD,
+    ) -> BOOL;
+    pub fn GetVolumeInformationW(
+        lpRootPathName: LPCWSTR,
+        lpVolumeNameBuffer: LPWSTR,
+        nVolumeNameSize: DWORD,
+        lpVolumeSerialNumber: LPDWORD,
+        lpMaximumComponentLength: LPDWORD,
+        lpFileSystemFlags: LPDWORD,
+        lpFileSystemNameBuffer: LPWSTR,
+        nFileSystemNameSize: DWORD,
+    ) -> BOOL;
+    pub fn GetVolumePathNameW(
+        lpszFileName: LPCWSTR,
+        lpszVolumePathName: LPWSTR,
+        cchBufferLength: DWORD,
+    ) -> BOOL;
+    pub fn LocalFileTimeToFileTime(
+        lpLocalFileTime: *const FILETIME,
+        lpFileTime: LPFILETIME,
+    ) -> BOOL;
+    pub fn LockFile(
+        hFile: HANDLE,
+        dwFileOffsetLow: DWORD,
+        dwFileOffsetHigh: DWORD,
+        nNumberOfBytesToLockLow: DWORD,
+        nNumberOfBytesToLockHigh: DWORD,
+    ) -> BOOL;
+    pub fn LockFileEx(
+        hFile: HANDLE,
+        dwFlags: DWORD,
+        dwReserved: DWORD,
+        nNumberOfBytesToLockLow: DWORD,
+        nNumberOfBytesToLockHigh: DWORD,
+        lpOverlapped: LPOVERLAPPED,
+    ) -> BOOL;
+    pub fn QueryDosDeviceW(
+        lpDeviceName: LPCWSTR,
+        lpTargetPath: LPWSTR,
+        ucchMax: DWORD
+    ) -> DWORD;
+    pub fn ReadFile(
+        hFile: HANDLE,
+        lpBuffer: LPVOID,
+        nNumberOfBytesToRead: DWORD,
+        lpNumberOfBytesRead: LPDWORD,
+        lpOverlapped: LPOVERLAPPED,
+    ) -> BOOL;
+    pub fn ReadFileEx(
+        hFile: HANDLE,
+        lpBuffer: LPVOID,
+        nNumberOfBytesToRead: DWORD,
+        lpOverlapped: LPOVERLAPPED,
+        lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
+    ) -> BOOL;
+    pub fn ReadFileScatter(
+        hFile: HANDLE,
+        aSegmentArray: *mut FILE_SEGMENT_ELEMENT,
+        nNumberOfBytesToRead: DWORD,
+        lpReserved: LPDWORD,
+        lpOverlapped: LPOVERLAPPED,
+    ) -> BOOL;
+    pub fn RemoveDirectoryA(
+        lpPathName: LPCSTR
+    ) -> BOOL;
+    pub fn RemoveDirectoryW(
+        lpPathName: LPCWSTR
+    ) -> BOOL;
+    pub fn SetEndOfFile(
+        hFile: HANDLE
+    ) -> BOOL;
+    pub fn SetFileAttributesA(
+        lpFileName: LPCSTR,
+        dwFileAttributes: DWORD
+    ) -> BOOL;
+    pub fn SetFileAttributesW(
+        lpFileName: LPCWSTR,
+        dwFileAttributes: DWORD
+    ) -> BOOL;
+    pub fn SetFileInformationByHandle(
+        hFile: HANDLE,
+        FileInformationClass: FILE_INFO_BY_HANDLE_CLASS,
+        lpFileInformation: LPVOID,
+        dwBufferSize: DWORD,
+    ) -> BOOL;
+    pub fn SetFilePointer(
+        hFile: HANDLE,
+        lDistanceToMove: LONG,
+        lpDistanceToMoveHigh: PLONG,
+        dwMoveMethod: DWORD,
+    ) -> DWORD;
+    pub fn SetFilePointerEx(
+        hFile: HANDLE,
+        liDistanceToMove: LARGE_INTEGER,
+        lpNewFilePointer: PLARGE_INTEGER,
+        dwMoveMethod: DWORD,
+    ) -> BOOL;
+    pub fn SetFileTime(
+        hFile: HANDLE,
+        lpCreationTime: *const FILETIME,
+        lpLastAccessTime: *const FILETIME,
+        lpLastWriteTime: *const FILETIME,
+    ) -> BOOL;
+    pub fn SetFileValidData(
+        hFile: HANDLE,
+        ValidDataLength: LONGLONG
+    ) -> BOOL;
+    pub fn UnlockFile(
+        hFile: HANDLE,
+        dwFileOffsetLow: DWORD,
+        dwFileOffsetHigh: DWORD,
+        nNumberOfBytesToUnlockLow: DWORD,
+        nNumberOfBytesToUnlockHigh: DWORD,
+    ) -> BOOL;
+    pub fn UnlockFileEx(
+        hFile: HANDLE,
+        dwReserved: DWORD,
+        nNumberOfBytesToUnlockLow: DWORD,
+        nNumberOfBytesToUnlockHigh: DWORD,
+        lpOverlapped: LPOVERLAPPED,
+    ) -> BOOL;
+    pub fn WriteFile(
+        hFile: HANDLE,
+        lpBuffer: LPCVOID,
+        nNumberOfBytesToWrite: DWORD,
+        lpNumberOfBytesWritten: LPDWORD,
+        lpOverlapped: LPOVERLAPPED,
+    ) -> BOOL;
+    pub fn WriteFileEx(
+        hFile: HANDLE,
+        lpBuffer: LPCVOID,
+        nNumberOfBytesToWrite: DWORD,
+        lpOverlapped: LPOVERLAPPED,
+        lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
+    ) -> BOOL;
+    pub fn WriteFileGather(
+        hFile: HANDLE,
+        aSegmentArray: *mut FILE_SEGMENT_ELEMENT,
+        nNumberOfBytesToWrite: DWORD,
+        lpReserved: LPDWORD,
+        lpOverlapped: LPOVERLAPPED,
+    ) -> BOOL;
+    pub fn GetTempPathW(
+        nBufferLength: DWORD,
+        lpBuffer: LPWSTR
+    ) -> DWORD;
+    pub fn GetVolumeNameForVolumeMountPointW(
+        lpszVolumeMountPoint: LPCWSTR,
+        lpszVolumeName: LPWSTR,
+        cchBufferLength: DWORD,
+    ) -> BOOL;
+    pub fn GetVolumePathNamesForVolumeNameW(
+        lpszVolumeName: LPCWSTR,
+        lpszVolumePathNames: LPWCH,
+        cchBufferLength: DWORD,
+        lpcchReturnLength: PDWORD,
+    ) -> BOOL;
+    pub fn CreateFile2(
+        lpFileName: LPCWSTR,
+        dwDesiredAccess: DWORD,
+        dwShareMode: DWORD,
+        dwCreationDisposition: DWORD,
+        pCreateExParams: LPCREATEFILE2_EXTENDED_PARAMETERS,
+    ) -> HANDLE;
+    pub fn SetFileIoOverlappedRange(
+        FileHandle: HANDLE,
+        OverlappedRangeStart: PUCHAR,
+        Length: ULONG,
+    ) -> BOOL;
+    pub fn GetCompressedFileSizeA(
+        lpFileName: LPCSTR,
+        lpFileSizeHigh: LPDWORD
+    ) -> DWORD;
+    pub fn GetCompressedFileSizeW(
+        lpFileName: LPCWSTR,
+        lpFileSizeHigh: LPDWORD
+    ) -> DWORD;
+    pub fn FindFirstStreamW(
+        lpFileName: LPCWSTR,
+        InfoLevel: STREAM_INFO_LEVELS,
+        lpFindStreamData: LPVOID,
+        dwFlags: DWORD,
+    ) -> HANDLE;
+    pub fn FindNextStreamW(
+        hFindStream: HANDLE,
+        lpFindStreamData: LPVOID
+    ) -> BOOL;
+    pub fn AreFileApisANSI() -> BOOL;
+    pub fn GetTempPathA(
+        nBufferLength: DWORD,
+        lpBuffer: LPSTR
+    ) -> DWORD;
+    pub fn FindFirstFileNameW(
+        lpFileName: LPCWSTR,
+        dwFlags: DWORD,
+        StringLength: LPDWORD,
+        LinkName: PWSTR,
+    ) -> HANDLE;
+    pub fn FindNextFileNameW(
+        hFindStream: HANDLE,
+        StringLength: LPDWORD,
+        LinkName: PWSTR
+    ) -> BOOL;
+    pub fn GetVolumeInformationA(
+        lpRootPathName: LPCSTR,
+        lpVolumeNameBuffer: LPSTR,
+        nVolumeNameSize: DWORD,
+        lpVolumeSerialNumber: LPDWORD,
+        lpMaximumComponentLength: LPDWORD,
+        lpFileSystemFlags: LPDWORD,
+        lpFileSystemNameBuffer: LPSTR,
+        nFileSystemNameSize: DWORD,
+    ) -> BOOL;
+    pub fn GetTempFileNameA(
+        lpPathName: LPCSTR,
+        lpPrefixString: LPCSTR,
+        uUnique: UINT,
+        lpTempFileName: LPSTR,
+    ) -> UINT;
+    pub fn SetFileApisToOEM();
+    pub fn SetFileApisToANSI();
+}


### PR DESCRIPTION
Not positive about the changes to build.rs, but I think they're right.