### PR TITLE
IID_NULL and some oleauto.h stuff

### DIFF
--- a/src/shared/guiddef.rs
+++ b/src/shared/guiddef.rs
@@ -27,6 +27,8 @@ pub type REFGUID = *const GUID;
 pub type REFIID = *const IID;
 pub type REFCLSID = *const IID;
 pub type REFFMTID = *const IID;
+DEFINE_GUID!{IID_NULL,
+    0x00000000, 0x0000, 0x0000, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 #[inline]
 pub fn IsEqualGUID(g1: &GUID, g2: &GUID) -> bool {
     let a = unsafe { &*(g1 as *const _ as *const [u32; 4]) };

--- a/src/um/oleauto.rs
+++ b/src/um/oleauto.rs
@@ -7,14 +7,12 @@
 //! Mappings for the contents of OleAuto.h
 
 use ctypes::c_uint;
-use shared::minwindef::UINT;
-use shared::wtypes::{BSTR};
+use shared::minwindef::{UINT, USHORT, WORD};
+use shared::wtypes::{BSTR, VARTYPE};
 use shared::wtypesbase::{LPCOLESTR, OLECHAR};
-use um::oaidl::{DISPID_UNKNOWN, ITypeLib};
-use um::winnt::{HRESULT, INT, LONG, LPCSTR};
+use um::oaidl::{DISPID_UNKNOWN, ITypeLib, VARIANT, VARIANTARG};
+use um::winnt::{HRESULT, INT, LCID, LONG, LPCSTR};
 
-pub type DISPID = LONG;
-pub type MEMBERID = DISPID;
 extern "system" {
     pub fn SysAllocString(
         psz: *const OLECHAR,
@@ -34,7 +32,7 @@ extern "system" {
     ) -> INT;
     pub fn SysFreeString(
         bstrString: BSTR,
-    ) -> ();
+    );
     pub fn SysStringLen(
         pbstr: BSTR,
     ) -> UINT;
@@ -45,9 +43,41 @@ extern "system" {
         psz: LPCSTR,
         len: UINT,
     ) -> BSTR;
+    pub fn VariantInit(
+        pvarg: *mut VARIANTARG,
+    );
+    pub fn VariantClear(
+        pvarg: *mut VARIANTARG,
+    ) -> HRESULT;
+    pub fn VariantCopy(
+        pvargDest: *mut VARIANTARG,
+        pvargSrc: *const VARIANTARG,
+    ) -> HRESULT;
+    pub fn VariantCopyInd(
+        pvarDest: *mut VARIANT,
+        pvargSrc: *const VARIANTARG,
+    ) -> HRESULT;
+    pub fn VariantChangeType(
+        pvargDest: *mut VARIANTARG,
+        pvarSrc: *const VARIANTARG,
+        wFlags: USHORT,
+        vt: VARTYPE,
+    ) -> HRESULT;
+    pub fn VariantChangeTypeEx(
+        pvargDest: *mut VARIANTARG,
+        pvarSrc: *const VARIANTARG,
+        lcid: LCID,
+        wFlags: USHORT,
+        vt: VARTYPE,
+    ) -> HRESULT;
 }
+pub type DISPID = LONG;
+pub type MEMBERID = DISPID;
 pub const MEMBERID_NIL: MEMBERID = DISPID_UNKNOWN;
-
+pub const DISPATCH_METHOD: WORD = 0x1;
+pub const DISPATCH_PROPERTYGET: WORD = 0x2;
+pub const DISPATCH_PROPERTYPUT: WORD = 0x4;
+pub const DISPATCH_PROPERTYPUTREF: WORD = 0x8;
 ENUM!{enum REGKIND {
     REGKIND_DEFAULT = 0,
     REGKIND_REGISTER,
@@ -56,7 +86,7 @@ ENUM!{enum REGKIND {
 extern "system" {
     pub fn LoadTypeLibEx(
         szFile: LPCOLESTR,
-        regKind: REGKIND,
+        regkind: REGKIND,
         pptlib: *mut *mut ITypeLib,
     ) -> HRESULT;
 }


### PR DESCRIPTION
- `IID_NULL` is `#define`'d to `GUID_NULL` in the actual header, but as discussed on IRC you didn't want `shared/guiddef` to take a dependency on `um/cguid` and preferred to duplicate the definition instead.

- Basic `Variant*` functions

- Fixed the order of the two typedefs to match their order in `oleauto.h`

- Fixed the name of the second parameter of `LoadTypeLibEx` to match the header.

- The type of the four `DISPATCH_*` consts comes from their use as the `wFlags` parameter of [IDispatch::Invoke](https://msdn.microsoft.com/en-us/library/windows/desktop/ms221479(v=vs.85).aspx)