### PR TITLE
Add rustfmt config file

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+fn_args_density = "Vertical"
+fn_args_layout = "Block"
+fn_call_width = 0
+trailing_comma = "Always"


### PR DESCRIPTION
This follows the winapi-rs-specific style guidelines, but it doesn't work properly for functions with 1 argument, so not currently stable for running on the whole repo, but this would assist with porting. I've already filed a bug with upstream (rust-lang-nursery/rustfmt#1508).