### PR TITLE
Fix misspelled field in DXGI_ADAPTER_DESC definition

### DIFF
--- a/src/shared/dxgi.rs
+++ b/src/shared/dxgi.rs
@@ -30,7 +30,7 @@ STRUCT!{struct DXGI_MAPPED_RECT {
 }}
 STRUCT!{struct DXGI_ADAPTER_DESC {
     Description: [WCHAR; 128],
-    VectorId: UINT,
+    VendorId: UINT,
     DeviceId: UINT,
     SubSysId: UINT,
     Revision: UINT,


### PR DESCRIPTION
This pull request fixes the `DXGI_ADAPTER_DESC`. It has a field called `VectorId`, when it should be `VendorId`.