### PR TITLE
add SOCKADDR_IN6

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,7 +65,7 @@ const DATA: &'static [(&'static str, &'static [&'static str], &'static [&'static
     ("winusbio", &["minwindef", "usb"], &[]),
     ("wnnc", &["minwindef"], &[]),
     ("ws2def", &["basetsd", "guiddef", "inaddr", "minwindef", "vcruntime", "winnt"], &[]),
-    ("ws2ipdef", &["in6addr", "inaddr", "minwindef"], &[]),
+    ("ws2ipdef", &["in6addr", "inaddr", "minwindef", "ws2def"], &[]),
     ("wtypes", &["guiddef", "minwindef", "ntdef", "wtypesbase"], &[]),
     ("wtypesbase", &["minwindef", "rpcndr", "winnt"], &[]),
     // ucrt

--- a/src/shared/ws2ipdef.rs
+++ b/src/shared/ws2ipdef.rs
@@ -9,7 +9,8 @@
 use ctypes::c_int;
 use shared::in6addr::IN6_ADDR;
 use shared::inaddr::IN_ADDR;
-use shared::minwindef::ULONG;
+use shared::minwindef::{ULONG, USHORT};
+use shared::ws2def::{ADDRESS_FAMILY, SCOPE_ID};
 
 pub const IP_OPTIONS: c_int = 1;
 pub const IP_HDRINCL: c_int = 2;
@@ -63,3 +64,16 @@ STRUCT!{struct IPV6_MREQ {
     ipv6mr_interface: ULONG,
 }}
 pub type PIPV6_MREQ = *mut IPV6_MREQ;
+UNION!{union SOCKADDR_IN6_LH_u {
+    [u32; 1],
+    sin6_scope_id sin6_scope_id_mut: ULONG,
+    sin6_scope_struct sin6_scope_struct_mut: SCOPE_ID,
+}}
+STRUCT!{struct SOCKADDR_IN6_LH {
+  sin6_family: ADDRESS_FAMILY,
+  sin6_port: USHORT,
+  sin6_flowinfo: ULONG,
+  sin6_addr: IN6_ADDR,
+  u: SOCKADDR_IN6_LH_u,
+}}
+pub type PSOCKADDR_IN6_LH = *mut SOCKADDR_IN6_LH;


### PR DESCRIPTION
Per #533 

Actually, since we're breaking anyway, I've deviated from the 0.2 version which had `sockaddr_in6` and instead provided [`SOCKADDR_IN6`](https://msdn.microsoft.com/en-us/library/windows/hardware/ff570824(v=vs.85).aspx) - since this seems like it's more consistent with having `SOCKADDR_IN`.

It's possible that I haven't grokked whatever naming convention you would have used for the inner union, but so far as I can tell this definition does what I expect when I use it.