### PR TITLE
include missing dbghelp library for dbghelp feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -118,7 +118,7 @@ const DATA: &'static [(&'static str, &'static [&'static str], &'static [&'static
     ("d3dx10mesh", &[], &[]),
     ("datetimeapi", &["minwinbase", "minwindef", "winnt"], &["kernel32"]),
     ("davclnt", &["minwindef", "winnt"], &["netapi32"]),
-    ("dbghelp", &["basetsd", "guiddef", "minwindef", "vcruntime", "winnt"], &[]),
+    ("dbghelp", &["basetsd", "guiddef", "minwindef", "vcruntime", "winnt"], &["dbghelp"]),
     ("dcommon", &["dxgiformat"], &[]),
     ("dcomp", &["d2d1", "d2d1_1", "d2d1effects", "d2dbasetypes", "d3d9types", "d3dcommon", "dcompanimation", "dcomptypes", "dxgi", "dxgi1_2", "dxgiformat", "guiddef", "minwinbase", "minwindef", "ntdef", "unknwnbase", "windef"], &["dcomp"]),
     ("dcompanimation", &["ntdef", "unknwnbase"], &[]),


### PR DESCRIPTION
As discussed on IRC, the library include is missing here 
and leads to some failures when using stuff from dbhelp.

[Before this PR: error LNK2001: unresolved external symbol SymGetModuleBase64
](https://ci.appveyor.com/project/alexcrichton/backtrace-rs/build/1.0.647/job/a6c2br3vuka11hjp)

[Testing against this PR shows it's fixed](https://ci.appveyor.com/project/alexcrichton/backtrace-rs/build/1.0.648/job/4ny433425tllp71k)