### PR TITLE
Add event log related FFI imports

### DIFF
--- a/src/um/winbase.rs
+++ b/src/um/winbase.rs
@@ -1960,20 +1960,48 @@ extern "system" {
     // pub fn BackupEventLogA();
     // pub fn BackupEventLogW();
     // pub fn CloseEventLog();
-    // pub fn DeregisterEventSource();
+    pub fn DeregisterEventSource(
+        hEventLog: HANDLE,
+    ) -> BOOL;
     // pub fn NotifyChangeEventLog();
     // pub fn GetNumberOfEventLogRecords();
     // pub fn GetOldestEventLogRecord();
     // pub fn OpenEventLogA();
     // pub fn OpenEventLogW();
-    // pub fn RegisterEventSourceA();
-    // pub fn RegisterEventSourceW();
+    pub fn RegisterEventSourceA(
+        lpUNCServerName: LPCSTR,
+        lpSourceName: LPCSTR,
+    ) -> HANDLE;
+    pub fn RegisterEventSourceW(
+        lpUNCServerName: LPCWSTR,
+        lpSourceName: LPCWSTR,
+    ) -> HANDLE;
     // pub fn OpenBackupEventLogA();
     // pub fn OpenBackupEventLogW();
     // pub fn ReadEventLogA();
     // pub fn ReadEventLogW();
-    // pub fn ReportEventA();
-    // pub fn ReportEventW();
+    pub fn ReportEventA(
+        hEventLog: HANDLE,
+        wType: WORD,
+        wCategory: WORD,
+        dwEventID: DWORD,
+        lpUserSid: PSID,
+        wNumStrings: WORD,
+        dwDataSize: DWORD,
+        lpStrings: *mut LPCSTR,
+        lpRawData: LPVOID,
+    ) -> BOOL;
+    pub fn ReportEventW(
+        hEventLog: HANDLE,
+        wType: WORD,
+        wCategory: WORD,
+        dwEventID: DWORD,
+        lpUserSid: PSID,
+        wNumStrings: WORD,
+        dwDataSize: DWORD,
+        lpStrings: *mut LPCWSTR,
+        lpRawData: LPVOID,
+    ) -> BOOL;
     // pub fn GetEventLogInformation();
     // pub fn OperationStart();
     // pub fn OperationEnd();


### PR DESCRIPTION
This PR adds missing exports for [DeregisterEventSource](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363642(v=vs.85).aspx), [RegisterEventSource](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363678(v=vs.85).aspx), [ReportEvent](
https://msdn.microsoft.com/en-us/library/windows/desktop/aa363679(v=vs.85).aspx).

