### PR TITLE
Add PURGE_* constants for use with PurgeComm function

### DIFF
--- a/src/um/winbase.rs
+++ b/src/um/winbase.rs
@@ -321,7 +321,10 @@ pub const CLRDTR: DWORD = 6;
 pub const RESETDEV: DWORD = 7;
 pub const SETBREAK: DWORD = 8;
 pub const CLRBREAK: DWORD = 9;
-// PURGE_*
+pub const PURGE_TXABORT: DWORD = 0x0001;
+pub const PURGE_RXABORT: DWORD = 0x0002;
+pub const PURGE_TXCLEAR: DWORD = 0x0004;
+pub const PURGE_RXCLEAR: DWORD = 0x0008;
 pub const MS_CTS_ON: DWORD = 0x0010;
 pub const MS_DSR_ON: DWORD = 0x0020;
 pub const MS_RING_ON: DWORD = 0x0040;


### PR DESCRIPTION
Adds four constants used for the [`dwFlags` argument to `PurgeComm`](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-purgecomm).

Definitions taken from `Winbase.h`.

This contribution has been pushed upstream from [this merge request](https://gitlab.com/susurrus/serialport-rs/merge_requests/46) in `serialport-rs`.