### PR TITLE
Add pub modifier to tuple constructor in UNION macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -253,7 +253,7 @@ macro_rules! UNION {
         $($variant:ident $variant_mut:ident: $ftype:ty,)+
     }) => (
         #[repr(C)] $(#[$attrs])*
-        pub struct $name([$stype; $ssize]);
+        pub struct $name(pub [$stype; $ssize]);
         impl Copy for $name {}
         impl Clone for $name {
             #[inline]
@@ -280,9 +280,9 @@ macro_rules! UNION {
         $($variant:ident $variant_mut:ident: $ftype:ty,)+
     }) => (
         #[repr(C)] $(#[$attrs])* #[cfg(target_arch = "x86")]
-        pub struct $name([$stype32; $ssize32]);
+        pub struct $name(pub [$stype32; $ssize32]);
         #[repr(C)] $(#[$attrs])* #[cfg(target_arch = "x86_64")]
-        pub struct $name([$stype64; $ssize64]);
+        pub struct $name(pub [$stype64; $ssize64]);
         impl Copy for $name {}
         impl Clone for $name {
             #[inline]


### PR DESCRIPTION
Generated structs by UNION macros has no pub modifier in its tuple constructor, hence their creation is not possible:
```
50 |         let u = OVERLAPPED_u([0]);
   |                 ^^^^^^^^^^^^ constructor is not visible here due to private fields
```
Macro produces:
```rust
pub struct OVERLAPPED_u([u64; 1]); // before
pub struct OVERLAPPED_u(pub [u64; 1]); // after
```