### PR TITLE
add support for aarch64-pc-windows-msvc

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -297,7 +297,7 @@ macro_rules! UNION {
     }) => (
         #[repr(C)] $(#[$attrs])* #[cfg(target_arch = "x86")]
         pub struct $name([$stype32; $ssize32]);
-        #[repr(C)] $(#[$attrs])* #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        #[repr(C)] $(#[$attrs])* #[cfg(target_pointer_width = "64")]
         pub struct $name([$stype64; $ssize64]);
         impl Copy for $name {}
         impl Clone for $name {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -297,7 +297,7 @@ macro_rules! UNION {
     }) => (
         #[repr(C)] $(#[$attrs])* #[cfg(target_arch = "x86")]
         pub struct $name([$stype32; $ssize32]);
-        #[repr(C)] $(#[$attrs])* #[cfg(target_arch = "x86_64")]
+        #[repr(C)] $(#[$attrs])* #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         pub struct $name([$stype64; $ssize64]);
         impl Copy for $name {}
         impl Clone for $name {

--- a/src/shared/basetsd.rs
+++ b/src/shared/basetsd.rs
@@ -41,19 +41,19 @@ pub type SHANDLE_PTR = isize;
 pub type HANDLE_PTR = usize;
 #[cfg(target_arch = "x86")]
 pub type UHALF_PTR = c_ushort;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type UHALF_PTR = c_uint;
 #[cfg(target_arch = "x86")]
 pub type PUHALF_PTR = *mut c_ushort;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type PUHALF_PTR = *mut c_uint;
 #[cfg(target_arch = "x86")]
 pub type HALF_PTR = c_short;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type HALF_PTR = c_int;
 #[cfg(target_arch = "x86")]
 pub type PHALF_PTR = *mut c_short;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type PHALF_PTR = *mut c_int;
 pub type SIZE_T = ULONG_PTR;
 pub type PSIZE_T = *mut ULONG_PTR;

--- a/src/shared/basetsd.rs
+++ b/src/shared/basetsd.rs
@@ -41,19 +41,19 @@ pub type SHANDLE_PTR = isize;
 pub type HANDLE_PTR = usize;
 #[cfg(target_arch = "x86")]
 pub type UHALF_PTR = c_ushort;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type UHALF_PTR = c_uint;
 #[cfg(target_arch = "x86")]
 pub type PUHALF_PTR = *mut c_ushort;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type PUHALF_PTR = *mut c_uint;
 #[cfg(target_arch = "x86")]
 pub type HALF_PTR = c_short;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type HALF_PTR = c_int;
 #[cfg(target_arch = "x86")]
 pub type PHALF_PTR = *mut c_short;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type PHALF_PTR = *mut c_int;
 pub type SIZE_T = ULONG_PTR;
 pub type PSIZE_T = *mut ULONG_PTR;

--- a/src/shared/usb.rs
+++ b/src/shared/usb.rs
@@ -420,7 +420,7 @@ STRUCT!{struct URB_CONTROL_TRANSFER {
     hca: URB_HCD_AREA,
     SetupPacket: [UCHAR; 8],
 }}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 STRUCT!{struct URB_CONTROL_TRANSFER_EX {
     Hdr: URB_HEADER,
     PipeHandle: USBD_PIPE_HANDLE,

--- a/src/shared/usb.rs
+++ b/src/shared/usb.rs
@@ -420,7 +420,7 @@ STRUCT!{struct URB_CONTROL_TRANSFER {
     hca: URB_HCD_AREA,
     SetupPacket: [UCHAR; 8],
 }}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 STRUCT!{struct URB_CONTROL_TRANSFER_EX {
     Hdr: URB_HEADER,
     PipeHandle: USBD_PIPE_HANDLE,

--- a/src/um/commctrl.rs
+++ b/src/um/commctrl.rs
@@ -6,7 +6,7 @@
 // except according to those terms.
 use ctypes::{c_char, c_int, c_long, c_short, c_void};
 use shared::basetsd::{DWORD_PTR, INT_PTR, LONG_PTR, UINT_PTR};
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] use shared::basetsd::PINT_PTR;
+#[cfg(target_pointer_width = "64")] use shared::basetsd::PINT_PTR;
 use shared::guiddef::{IID, REFIID};
 use shared::minwindef::{
     BOOL, BYTE, DWORD, HINSTANCE, HKEY, INT, LPARAM, LPINT, LRESULT, PUINT, UINT, ULONG, WORD,
@@ -781,7 +781,7 @@ STRUCT!{struct TBBUTTON {
     dwData: DWORD_PTR,
     iString: INT_PTR,
 }}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 STRUCT!{struct TBBUTTON {
     iBitmap: c_int,
     idCommand: c_int,
@@ -4033,7 +4033,7 @@ extern "system" {
         propIndex: c_int,
         pValue: LPINT,
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn FlatSB_GetScrollPropPtr(
         hWnd: HWND,
         propIndex: c_int,

--- a/src/um/commctrl.rs
+++ b/src/um/commctrl.rs
@@ -6,7 +6,7 @@
 // except according to those terms.
 use ctypes::{c_char, c_int, c_long, c_short, c_void};
 use shared::basetsd::{DWORD_PTR, INT_PTR, LONG_PTR, UINT_PTR};
-#[cfg(target_arch = "x86_64")] use shared::basetsd::PINT_PTR;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] use shared::basetsd::PINT_PTR;
 use shared::guiddef::{IID, REFIID};
 use shared::minwindef::{
     BOOL, BYTE, DWORD, HINSTANCE, HKEY, INT, LPARAM, LPINT, LRESULT, PUINT, UINT, ULONG, WORD,
@@ -781,7 +781,7 @@ STRUCT!{struct TBBUTTON {
     dwData: DWORD_PTR,
     iString: INT_PTR,
 }}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 STRUCT!{struct TBBUTTON {
     iBitmap: c_int,
     idCommand: c_int,
@@ -4033,7 +4033,7 @@ extern "system" {
         propIndex: c_int,
         pValue: LPINT,
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn FlatSB_GetScrollPropPtr(
         hWnd: HWND,
         propIndex: c_int,

--- a/src/um/dbghelp.rs
+++ b/src/um/dbghelp.rs
@@ -19,10 +19,10 @@ use um::winnt::{
     PFPO_DATA, PIMAGE_COFF_SYMBOLS_HEADER, PIMAGE_DEBUG_DIRECTORY, PIMAGE_FUNCTION_ENTRY,
     PIMAGE_NT_HEADERS32,
 };
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use um::winnt::PIMAGE_NT_HEADERS64;
 use vc::vcruntime::size_t;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 STRUCT!{struct LOADED_IMAGE {
     ModuleName: PSTR,
     hFile: HANDLE,
@@ -191,9 +191,9 @@ STRUCT!{struct ADDRESS64 {
     Mode: ADDRESS_MODE,
 }}
 pub type LPADDRESS64 = *mut ADDRESS64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type ADDRESS = ADDRESS64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type LPADDRESS = LPADDRESS64;
 #[cfg(target_arch = "x86")]
 STRUCT!{struct ADDRESS {
@@ -220,9 +220,9 @@ STRUCT!{struct KDHELP64 {
     Reserved1: [DWORD64; 4],
 }}
 pub type PKDHELP64 = *mut KDHELP64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type KDHELP = KDHELP64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type PKDHELP = PKDHELP64;
 #[cfg(target_arch = "x86")]
 STRUCT!{struct KDHELP {
@@ -273,9 +273,9 @@ STRUCT!{struct STACKFRAME_EX {
     InlineFrameContext: DWORD,
 }}
 pub type LPSTACKFRAME_EX = *mut STACKFRAME_EX;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type STACKFRAME = STACKFRAME64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type LPSTACKFRAME = LPSTACKFRAME64;
 #[cfg(target_arch = "x86")]
 STRUCT!{struct STACKFRAME {
@@ -315,13 +315,13 @@ FN!{stdcall PTRANSLATE_ADDRESS_ROUTINE64(
 ) -> DWORD64}
 pub const SYM_STKWALK_DEFAULT: DWORD = 0x00000000;
 pub const SYM_STKWALK_FORCE_FRAMEPTR: DWORD = 0x00000001;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type PREAD_PROCESS_MEMORY_ROUTINE = PREAD_PROCESS_MEMORY_ROUTINE64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type PFUNCTION_TABLE_ACCESS_ROUTINE = PFUNCTION_TABLE_ACCESS_ROUTINE64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type PGET_MODULE_BASE_ROUTINE = PGET_MODULE_BASE_ROUTINE64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type PTRANSLATE_ADDRESS_ROUTINE = PTRANSLATE_ADDRESS_ROUTINE64;
 #[cfg(target_arch = "x86")]
 FN!{stdcall PREAD_PROCESS_MEMORY_ROUTINE(

--- a/src/um/dbghelp.rs
+++ b/src/um/dbghelp.rs
@@ -19,10 +19,10 @@ use um::winnt::{
     PFPO_DATA, PIMAGE_COFF_SYMBOLS_HEADER, PIMAGE_DEBUG_DIRECTORY, PIMAGE_FUNCTION_ENTRY,
     PIMAGE_NT_HEADERS32,
 };
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 use um::winnt::PIMAGE_NT_HEADERS64;
 use vc::vcruntime::size_t;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 STRUCT!{struct LOADED_IMAGE {
     ModuleName: PSTR,
     hFile: HANDLE,
@@ -191,9 +191,9 @@ STRUCT!{struct ADDRESS64 {
     Mode: ADDRESS_MODE,
 }}
 pub type LPADDRESS64 = *mut ADDRESS64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type ADDRESS = ADDRESS64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type LPADDRESS = LPADDRESS64;
 #[cfg(target_arch = "x86")]
 STRUCT!{struct ADDRESS {
@@ -220,9 +220,9 @@ STRUCT!{struct KDHELP64 {
     Reserved1: [DWORD64; 4],
 }}
 pub type PKDHELP64 = *mut KDHELP64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type KDHELP = KDHELP64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type PKDHELP = PKDHELP64;
 #[cfg(target_arch = "x86")]
 STRUCT!{struct KDHELP {
@@ -273,9 +273,9 @@ STRUCT!{struct STACKFRAME_EX {
     InlineFrameContext: DWORD,
 }}
 pub type LPSTACKFRAME_EX = *mut STACKFRAME_EX;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type STACKFRAME = STACKFRAME64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type LPSTACKFRAME = LPSTACKFRAME64;
 #[cfg(target_arch = "x86")]
 STRUCT!{struct STACKFRAME {
@@ -315,13 +315,13 @@ FN!{stdcall PTRANSLATE_ADDRESS_ROUTINE64(
 ) -> DWORD64}
 pub const SYM_STKWALK_DEFAULT: DWORD = 0x00000000;
 pub const SYM_STKWALK_FORCE_FRAMEPTR: DWORD = 0x00000001;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type PREAD_PROCESS_MEMORY_ROUTINE = PREAD_PROCESS_MEMORY_ROUTINE64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type PFUNCTION_TABLE_ACCESS_ROUTINE = PFUNCTION_TABLE_ACCESS_ROUTINE64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type PGET_MODULE_BASE_ROUTINE = PGET_MODULE_BASE_ROUTINE64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type PTRANSLATE_ADDRESS_ROUTINE = PTRANSLATE_ADDRESS_ROUTINE64;
 #[cfg(target_arch = "x86")]
 FN!{stdcall PREAD_PROCESS_MEMORY_ROUTINE(

--- a/src/um/lmdfs.rs
+++ b/src/um/lmdfs.rs
@@ -45,7 +45,7 @@ STRUCT!{struct DFS_INFO_1 {
 }}
 pub type PDFS_INFO_1 = *mut DFS_INFO_1;
 pub type LPDFS_INFO_1 = *mut DFS_INFO_1;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 STRUCT!{struct DFS_INFO_1_32 {
     EntryPath: ULONG,
@@ -61,7 +61,7 @@ STRUCT!{struct DFS_INFO_2 {
 }}
 pub type PDFS_INFO_2 = *mut DFS_INFO_2;
 pub type LPDFS_INFO_2 = *mut DFS_INFO_2;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 STRUCT!{struct DFS_INFO_2_32 {
     EntryPath: ULONG,
@@ -79,7 +79,7 @@ STRUCT!{struct DFS_STORAGE_INFO {
 }}
 pub type PDFS_STORAGE_INFO = *mut DFS_STORAGE_INFO;
 pub type LPDFS_STORAGE_INFO = *mut DFS_STORAGE_INFO;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 STRUCT!{struct DFS_STORAGE_INFO_0_32 {
     State: ULONG,
@@ -106,7 +106,7 @@ STRUCT!{struct DFS_INFO_3 {
 }}
 pub type PDFS_INFO_3 = *mut DFS_INFO_3;
 pub type LPDFS_INFO_3 = *mut DFS_INFO_3;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 STRUCT!{struct DFS_INFO_3_32 {
     EntryPath: ULONG,
@@ -129,7 +129,7 @@ STRUCT!{struct DFS_INFO_4 {
 }}
 pub type PDFS_INFO_4 = *mut DFS_INFO_4;
 pub type LPDFS_INFO_4 = *mut DFS_INFO_4;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 STRUCT!{struct DFS_INFO_4_32 {
     EntryPath: ULONG,

--- a/src/um/lmdfs.rs
+++ b/src/um/lmdfs.rs
@@ -45,7 +45,7 @@ STRUCT!{struct DFS_INFO_1 {
 }}
 pub type PDFS_INFO_1 = *mut DFS_INFO_1;
 pub type LPDFS_INFO_1 = *mut DFS_INFO_1;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 STRUCT!{struct DFS_INFO_1_32 {
     EntryPath: ULONG,
@@ -61,7 +61,7 @@ STRUCT!{struct DFS_INFO_2 {
 }}
 pub type PDFS_INFO_2 = *mut DFS_INFO_2;
 pub type LPDFS_INFO_2 = *mut DFS_INFO_2;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 STRUCT!{struct DFS_INFO_2_32 {
     EntryPath: ULONG,
@@ -79,7 +79,7 @@ STRUCT!{struct DFS_STORAGE_INFO {
 }}
 pub type PDFS_STORAGE_INFO = *mut DFS_STORAGE_INFO;
 pub type LPDFS_STORAGE_INFO = *mut DFS_STORAGE_INFO;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 STRUCT!{struct DFS_STORAGE_INFO_0_32 {
     State: ULONG,
@@ -106,7 +106,7 @@ STRUCT!{struct DFS_INFO_3 {
 }}
 pub type PDFS_INFO_3 = *mut DFS_INFO_3;
 pub type LPDFS_INFO_3 = *mut DFS_INFO_3;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 STRUCT!{struct DFS_INFO_3_32 {
     EntryPath: ULONG,
@@ -129,7 +129,7 @@ STRUCT!{struct DFS_INFO_4 {
 }}
 pub type PDFS_INFO_4 = *mut DFS_INFO_4;
 pub type LPDFS_INFO_4 = *mut DFS_INFO_4;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 STRUCT!{struct DFS_INFO_4_32 {
     EntryPath: ULONG,

--- a/src/um/nb30.rs
+++ b/src/um/nb30.rs
@@ -12,7 +12,7 @@ pub const MAX_LANA: usize = 254;
 FN!{stdcall PFPOST(
     *mut NCB,
 ) -> ()}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 STRUCT!{struct NCB {
     ncb_command: UCHAR,
     ncb_retcode: UCHAR,

--- a/src/um/nb30.rs
+++ b/src/um/nb30.rs
@@ -12,7 +12,7 @@ pub const MAX_LANA: usize = 254;
 FN!{stdcall PFPOST(
     *mut NCB,
 ) -> ()}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 STRUCT!{struct NCB {
     ncb_command: UCHAR,
     ncb_retcode: UCHAR,

--- a/src/um/oaidl.rs
+++ b/src/um/oaidl.rs
@@ -80,7 +80,7 @@ UNION!{union __MIDL_IOleAutomationTypes_0001 {
     LongStr LongStr_mut: DWORD_SIZEDARR,
     HyperStr HyperStr_mut: HYPER_SIZEDARR,
 }}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 UNION!{union __MIDL_IOleAutomationTypes_0001 {
     [u64; 4],
     BstrStr BstrStr_mut: SAFEARR_BSTR,

--- a/src/um/oaidl.rs
+++ b/src/um/oaidl.rs
@@ -80,7 +80,7 @@ UNION!{union __MIDL_IOleAutomationTypes_0001 {
     LongStr LongStr_mut: DWORD_SIZEDARR,
     HyperStr HyperStr_mut: HYPER_SIZEDARR,
 }}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 UNION!{union __MIDL_IOleAutomationTypes_0001 {
     [u64; 4],
     BstrStr BstrStr_mut: SAFEARR_BSTR,

--- a/src/um/sporder.rs
+++ b/src/um/sporder.rs
@@ -18,7 +18,7 @@ FN!{stdcall LPWSCWRITEPROVIDERORDER(
     lpwdCatalogEntryId: LPDWORD,
     dwNumberOfEntries: DWORD,
 ) -> c_int}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 extern "system" {
     pub fn WSCWriteProviderOrder32(
         lpwdCatalogEntryId: LPDWORD,
@@ -33,7 +33,7 @@ FN!{stdcall LPWSCWRITENAMESPACEORDER(
     lpProviderId: LPGUID,
     dwNumberOfEntries: DWORD,
 ) -> c_int}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 extern "system" {
     pub fn WSCWriteNameSpaceOrder32(
         lpProviderId: LPGUID,

--- a/src/um/sporder.rs
+++ b/src/um/sporder.rs
@@ -18,7 +18,7 @@ FN!{stdcall LPWSCWRITEPROVIDERORDER(
     lpwdCatalogEntryId: LPDWORD,
     dwNumberOfEntries: DWORD,
 ) -> c_int}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 extern "system" {
     pub fn WSCWriteProviderOrder32(
         lpwdCatalogEntryId: LPDWORD,
@@ -33,7 +33,7 @@ FN!{stdcall LPWSCWRITENAMESPACEORDER(
     lpProviderId: LPGUID,
     dwNumberOfEntries: DWORD,
 ) -> c_int}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 extern "system" {
     pub fn WSCWriteNameSpaceOrder32(
         lpProviderId: LPGUID,

--- a/src/um/sqltypes.rs
+++ b/src/um/sqltypes.rs
@@ -6,7 +6,7 @@
 // except according to those terms.
 //! This module defines the types used in ODBC
 use ctypes::*;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 use shared::basetsd::{INT64, UINT64};
 use shared::guiddef::GUID;
 use shared::windef::HWND;
@@ -18,11 +18,11 @@ pub type SQLDOUBLE = c_double;
 pub type SQLFLOAT = c_double;
 pub type SQLINTEGER = c_long;
 pub type SQLUINTEGER = c_ulong;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type SQLLEN = INT64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type SQLULEN = UINT64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub type SQLSETPOSIROW = UINT64;
 #[cfg(target_arch = "x86")]
 pub type SQLLEN = SQLINTEGER;

--- a/src/um/sqltypes.rs
+++ b/src/um/sqltypes.rs
@@ -6,7 +6,7 @@
 // except according to those terms.
 //! This module defines the types used in ODBC
 use ctypes::*;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use shared::basetsd::{INT64, UINT64};
 use shared::guiddef::GUID;
 use shared::windef::HWND;
@@ -18,11 +18,11 @@ pub type SQLDOUBLE = c_double;
 pub type SQLFLOAT = c_double;
 pub type SQLINTEGER = c_long;
 pub type SQLUINTEGER = c_ulong;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type SQLLEN = INT64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type SQLULEN = UINT64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type SQLSETPOSIROW = UINT64;
 #[cfg(target_arch = "x86")]
 pub type SQLLEN = SQLINTEGER;

--- a/src/um/winbase.rs
+++ b/src/um/winbase.rs
@@ -116,7 +116,7 @@ FN!{stdcall PFIBER_CALLOUT_ROUTINE(
 // FAIL_FAST_*
 #[cfg(target_arch = "x86")]
 pub type LPLDT_ENTRY = PLDT_ENTRY;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(not(target_arch = "x86"))]
 pub type LPLDT_ENTRY = LPVOID; // TODO - fix this for 32-bit
 //SP_SERIALCOMM
 //PST_*
@@ -543,40 +543,40 @@ BITFIELD!{UMS_SYSTEM_THREAD_INFORMATION ThreadUmsFlags: ULONG [
 ]}
 pub type PUMS_SYSTEM_THREAD_INFORMATION = *mut UMS_SYSTEM_THREAD_INFORMATION;
 extern "system" {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn CreateUmsCompletionList(
         UmsCompletionList: *mut PUMS_COMPLETION_LIST
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn DequeueUmsCompletionListItems(
         UmsCompletionList: PUMS_COMPLETION_LIST,
         WaitTimeOut: DWORD,
         UmsThreadList: *mut PUMS_CONTEXT,
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn GetUmsCompletionListEvent(
         UmsCompletionList: PUMS_COMPLETION_LIST,
         UmsCompletionEvent: PHANDLE,
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn ExecuteUmsThread(
         UmsThread: PUMS_CONTEXT
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn UmsThreadYield(
         SchedulerParam: PVOID
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn DeleteUmsCompletionList(
         UmsCompletionList: PUMS_COMPLETION_LIST
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn GetCurrentUmsThread() -> PUMS_CONTEXT;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn GetNextUmsListItem(
         UmsContext: PUMS_CONTEXT
     ) -> PUMS_CONTEXT;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn QueryUmsThreadInformation(
         UmsThread: PUMS_CONTEXT,
         UmsThreadInfoClass: UMS_THREAD_INFO_CLASS,
@@ -584,26 +584,26 @@ extern "system" {
         UmsThreadInformationLength: ULONG,
         ReturnLength: PULONG,
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn SetUmsThreadInformation(
         UmsThread: PUMS_CONTEXT,
         UmsThreadInfoClass: UMS_THREAD_INFO_CLASS,
         UmsThreadInformation: PVOID,
         UmsThreadInformationLength: ULONG,
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn DeleteUmsThreadContext(
         UmsThread: PUMS_CONTEXT
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn CreateUmsThreadContext(
         lpUmsThread: *mut PUMS_CONTEXT
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn EnterUmsSchedulingMode(
         SchedulerStartupInfo: PUMS_SCHEDULER_STARTUP_INFO
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn GetUmsSystemThreadInformation(
         ThreadHandle: HANDLE,
         SystemThreadInfo: PUMS_SYSTEM_THREAD_INFORMATION,

--- a/src/um/winbase.rs
+++ b/src/um/winbase.rs
@@ -116,7 +116,7 @@ FN!{stdcall PFIBER_CALLOUT_ROUTINE(
 // FAIL_FAST_*
 #[cfg(target_arch = "x86")]
 pub type LPLDT_ENTRY = PLDT_ENTRY;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub type LPLDT_ENTRY = LPVOID; // TODO - fix this for 32-bit
 //SP_SERIALCOMM
 //PST_*
@@ -543,40 +543,40 @@ BITFIELD!{UMS_SYSTEM_THREAD_INFORMATION ThreadUmsFlags: ULONG [
 ]}
 pub type PUMS_SYSTEM_THREAD_INFORMATION = *mut UMS_SYSTEM_THREAD_INFORMATION;
 extern "system" {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn CreateUmsCompletionList(
         UmsCompletionList: *mut PUMS_COMPLETION_LIST
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn DequeueUmsCompletionListItems(
         UmsCompletionList: PUMS_COMPLETION_LIST,
         WaitTimeOut: DWORD,
         UmsThreadList: *mut PUMS_CONTEXT,
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn GetUmsCompletionListEvent(
         UmsCompletionList: PUMS_COMPLETION_LIST,
         UmsCompletionEvent: PHANDLE,
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn ExecuteUmsThread(
         UmsThread: PUMS_CONTEXT
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn UmsThreadYield(
         SchedulerParam: PVOID
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn DeleteUmsCompletionList(
         UmsCompletionList: PUMS_COMPLETION_LIST
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn GetCurrentUmsThread() -> PUMS_CONTEXT;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn GetNextUmsListItem(
         UmsContext: PUMS_CONTEXT
     ) -> PUMS_CONTEXT;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn QueryUmsThreadInformation(
         UmsThread: PUMS_CONTEXT,
         UmsThreadInfoClass: UMS_THREAD_INFO_CLASS,
@@ -584,26 +584,26 @@ extern "system" {
         UmsThreadInformationLength: ULONG,
         ReturnLength: PULONG,
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn SetUmsThreadInformation(
         UmsThread: PUMS_CONTEXT,
         UmsThreadInfoClass: UMS_THREAD_INFO_CLASS,
         UmsThreadInformation: PVOID,
         UmsThreadInformationLength: ULONG,
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn DeleteUmsThreadContext(
         UmsThread: PUMS_CONTEXT
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn CreateUmsThreadContext(
         lpUmsThread: *mut PUMS_CONTEXT
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn EnterUmsSchedulingMode(
         SchedulerStartupInfo: PUMS_SCHEDULER_STARTUP_INFO
     ) -> BOOL;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn GetUmsSystemThreadInformation(
         ThreadHandle: HANDLE,
         SystemThreadInfo: PUMS_SYSTEM_THREAD_INFORMATION,
@@ -1249,7 +1249,6 @@ extern "system" {
         hUpdate: HANDLE,
         fDiscard: BOOL
     ) -> BOOL;
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     pub fn GlobalAddAtomA(
         lpString: LPCSTR
     ) -> ATOM;

--- a/src/um/winnt.rs
+++ b/src/um/winnt.rs
@@ -13,6 +13,8 @@ use shared::basetsd::{
 use shared::guiddef::{CLSID, GUID};
 use shared::ktmtypes::UOW;
 use shared::minwindef::{BYTE, DWORD, FALSE, PDWORD, TRUE, ULONG, USHORT, WORD};
+#[cfg(target_arch = "aarch64")]
+use shared::minwindef::PBYTE;
 use vc::excpt::EXCEPTION_DISPOSITION;
 use vc::vcruntime::size_t;
 pub const ANYSIZE_ARRAY: usize = 1;
@@ -21,7 +23,7 @@ IFDEF!{
 pub const MAX_NATURAL_ALIGNMENT: usize = 4;
 pub const MEMORY_ALLOCATION_ALIGNMENT: usize = 8;
 }
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 pub const MAX_NATURAL_ALIGNMENT: usize = 8;
 pub const MEMORY_ALLOCATION_ALIGNMENT: usize = 16;
@@ -113,7 +115,7 @@ STRUCT!{struct GROUP_AFFINITY {
 pub type PGROUP_AFFINITY = *mut GROUP_AFFINITY;
 #[cfg(target_arch = "x86")]
 pub const MAXIMUM_PROC_PER_GROUP: BYTE = 32;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub const MAXIMUM_PROC_PER_GROUP: BYTE = 64;
 pub const MAXIMUM_PROCESSORS: BYTE = MAXIMUM_PROC_PER_GROUP;
 pub type HANDLE = *mut c_void;
@@ -952,18 +954,6 @@ STRUCT!{struct XSAVE_FORMAT { // FIXME align 16
     XmmRegisters: [M128A; 16],
     Reserved4: [BYTE; 96],
 }}
-pub type PXSAVE_FORMAT = *mut XSAVE_FORMAT;
-STRUCT!{struct XSAVE_AREA_HEADER { // FIXME align 8
-    Mask: DWORD64,
-    CompactionMask: DWORD64,
-    Reserved2: [DWORD64; 6],
-}}
-pub type PXSAVE_AREA_HEADER = *mut XSAVE_AREA_HEADER;
-STRUCT!{struct XSAVE_AREA { // FIXME align 16
-    LegacyState: XSAVE_FORMAT,
-    Header: XSAVE_AREA_HEADER,
-}}
-pub type PXSAVE_AREA = *mut XSAVE_AREA;
 #[cfg(target_arch = "x86")]
 STRUCT!{struct XSTATE_CONTEXT {
     Mask: DWORD64,
@@ -982,7 +972,22 @@ STRUCT!{struct XSTATE_CONTEXT {
     Area: PXSAVE_AREA,
     Buffer: PVOID,
 }}
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+IFDEF!{
+pub type PXSAVE_FORMAT = *mut XSAVE_FORMAT;
+STRUCT!{struct XSAVE_AREA_HEADER { // FIXME align 8
+    Mask: DWORD64,
+    CompactionMask: DWORD64,
+    Reserved2: [DWORD64; 6],
+}}
+pub type PXSAVE_AREA_HEADER = *mut XSAVE_AREA_HEADER;
+STRUCT!{struct XSAVE_AREA { // FIXME align 16
+    LegacyState: XSAVE_FORMAT,
+    Header: XSAVE_AREA_HEADER,
+}}
+pub type PXSAVE_AREA = *mut XSAVE_AREA;
 pub type PXSTATE_CONTEXT = *mut XSTATE_CONTEXT;
+}
 STRUCT!{struct SCOPE_TABLE_AMD64 {
     Count: DWORD,
     ScopeRecord: [SCOPE_TABLE_AMD64_ScopeRecord; 1],
@@ -994,6 +999,17 @@ STRUCT!{struct SCOPE_TABLE_AMD64_ScopeRecord {
     JumpTarget: DWORD,
 }}
 pub type PSCOPE_TABLE_AMD64 = *mut SCOPE_TABLE_AMD64;
+STRUCT!{struct SCOPE_TABLE_ARM64 {
+    Count: DWORD,
+    ScopeRecord: [SCOPE_TABLE_ARM64_ScopeRecord; 1],
+}}
+STRUCT!{struct SCOPE_TABLE_ARM64_ScopeRecord {
+    BeginAddress: DWORD,
+    EndAddress: DWORD,
+    HandlerAddress: DWORD,
+    JumpTarget: DWORD,
+}}
+pub type PSCOPE_TABLE_ARM64 = *mut SCOPE_TABLE_ARM64;
 // Skip interlocked and bit manipulation stuff because it is all intrinsics
 // Use the native Rust equivalents instead
 #[cfg(target_arch = "x86_64")]
@@ -1302,6 +1318,174 @@ STRUCT!{struct LDT_ENTRY {
     HighWord: LDT_ENTRY_HighWord,
 }}
 pub type PLDT_ENTRY = *mut LDT_ENTRY;
+#[cfg(target_arch = "aarch64")]
+IFDEF!{
+pub const ARM64_MAX_BREAKPOINTS: usize = 8;
+pub const ARM64_MAX_WATCHPOINTS: usize = 2;
+pub const EXCEPTION_READ_FAULT: DWORD = 0;
+pub const EXCEPTION_WRITE_FAULT: DWORD = 1;
+pub const EXCEPTION_EXECUTE_FAULT: DWORD = 8;
+pub const CONTEXT_ARM64: DWORD = 0x00400000;
+pub const CONTEXT_CONTROL: DWORD = CONTEXT_ARM64 | 0x00000001;
+pub const CONTEXT_INTEGER: DWORD = CONTEXT_ARM64 | 0x00000002;
+pub const CONTEXT_FLOATING_POINT: DWORD = CONTEXT_ARM64 | 0x00000004;
+pub const CONTEXT_DEBUG_REGISTERS: DWORD = CONTEXT_ARM64 | 0x00000008;
+pub const CONTEXT_X18: DWORD = CONTEXT_ARM64 | 0x00000010;
+pub const CONTEXT_FULL: DWORD = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT;
+pub const CONTEXT_ALL: DWORD = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT
+        | CONTEXT_DEBUG_REGISTERS | CONTEXT_X18;
+pub const CONTEXT_EXCEPTION_ACTIVE: DWORD = 0x08000000;
+pub const CONTEXT_SERVICE_ACTIVE: DWORD = 0x10000000;
+pub const CONTEXT_EXCEPTION_REQUEST: DWORD = 0x40000000;
+pub const CONTEXT_EXCEPTION_REPORTING: DWORD = 0x80000000;
+STRUCT!{struct CONTEXT_u_s {
+    X0: DWORD64,
+    X1: DWORD64,
+    X2: DWORD64,
+    X3: DWORD64,
+    X4: DWORD64,
+    X5: DWORD64,
+    X6: DWORD64,
+    X7: DWORD64,
+    X8: DWORD64,
+    X9: DWORD64,
+    X10: DWORD64,
+    X11: DWORD64,
+    X12: DWORD64,
+    X13: DWORD64,
+    X14: DWORD64,
+    X15: DWORD64,
+    X16: DWORD64,
+    X17: DWORD64,
+    X18: DWORD64,
+    X19: DWORD64,
+    X20: DWORD64,
+    X21: DWORD64,
+    X22: DWORD64,
+    X23: DWORD64,
+    X24: DWORD64,
+    X25: DWORD64,
+    X26: DWORD64,
+    X27: DWORD64,
+    X28: DWORD64,
+    Fp: DWORD64,
+    Lr: DWORD64,
+}}
+UNION!{union CONTEXT_u {
+    [u64; 31],
+    s s_mut: CONTEXT_u_s,
+}}
+STRUCT!{struct ARM64_NT_NEON128_s {
+    Low: ULONGLONG,
+    High: LONGLONG,
+}}
+UNION!{union ARM64_NT_NEON128 {
+    [u64; 2],
+    s s_mut: ARM64_NT_NEON128_s,
+    D D_mut: [f64; 2],
+    S S_mut: [f32; 4],
+    H H_mut: [WORD; 8],
+    B B_mut: [BYTE; 16],
+}}
+STRUCT!{struct CONTEXT { // FIXME align 16
+    ContextFlags: DWORD,
+    Cpsr: DWORD,
+    u: CONTEXT_u,
+    Sp: DWORD64,
+    Pc: DWORD64,
+    V: [ARM64_NT_NEON128; 32],
+    Fpcr: DWORD,
+    Fpsr: DWORD,
+    Bcr: [DWORD; ARM64_MAX_BREAKPOINTS],
+    Bvr: [DWORD64; ARM64_MAX_BREAKPOINTS],
+    Wcr: [DWORD; ARM64_MAX_WATCHPOINTS],
+    Wvr: [DWORD64; ARM64_MAX_WATCHPOINTS],
+}}
+pub type PCONTEXT = *mut CONTEXT;
+pub type RUNTIME_FUNCTION = IMAGE_RUNTIME_FUNCTION_ENTRY;
+pub type PRUNTIME_FUNCTION = *mut IMAGE_RUNTIME_FUNCTION_ENTRY;
+pub type SCOPE_TABLE = SCOPE_TABLE_ARM64;
+pub type PSCOPE_TABLE = *mut SCOPE_TABLE_ARM64;
+pub const RUNTIME_FUNCTION_INDIRECT: DWORD = 0x1;
+pub const UNW_FLAG_NHANDLER: DWORD = 0x0;
+pub const UNW_FLAG_EHANDLER: DWORD = 0x1;
+pub const UNW_FLAG_UHANDLER: DWORD = 0x2;
+pub const UNWIND_HISTORY_TABLE_SIZE: usize = 12;
+STRUCT!{struct UNWIND_HISTORY_TABLE_ENTRY {
+    ImageBase: DWORD64,
+    FunctionEntry: PRUNTIME_FUNCTION,
+}}
+pub type PUNWIND_HISTORY_TABLE_ENTRY = *mut UNWIND_HISTORY_TABLE_ENTRY;
+STRUCT!{struct UNWIND_HISTORY_TABLE {
+    Count: DWORD,
+    LocalHint: BYTE,
+    GlobalHint: BYTE,
+    Search: BYTE,
+    Once: BYTE,
+    LowAddress: DWORD64,
+    HighAddress: DWORD64,
+    Entry: [UNWIND_HISTORY_TABLE_ENTRY; UNWIND_HISTORY_TABLE_SIZE],
+}}
+pub type PUNWIND_HISTORY_TABLE = *mut UNWIND_HISTORY_TABLE;
+FN!{cdecl PGET_RUNTIME_FUNCTION_CALLBACK(
+    ControlPc: DWORD64,
+    Context: PVOID,
+) -> PRUNTIME_FUNCTION}
+FN!{cdecl POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK(
+    Process: HANDLE,
+    TableAddress: PVOID,
+    Entries: PDWORD,
+    Functions: *mut PRUNTIME_FUNCTION,
+) -> DWORD}
+pub const OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK_EXPORT_NAME: &'static str
+    = "OutOfProcessFunctionTableCallback";
+STRUCT!{struct DISPATCHER_CONTEXT {
+    ControlPc: ULONG_PTR,
+    ImageBase: ULONG_PTR,
+    FunctionEntry: PRUNTIME_FUNCTION,
+    EstablisherFrame: ULONG_PTR,
+    TargetPc: ULONG_PTR,
+    ContextRecord: PCONTEXT,
+    LanguageHandler: PEXCEPTION_ROUTINE,
+    HandlerData: PVOID,
+    HistoryTable: PUNWIND_HISTORY_TABLE,
+    ScopeIndex: DWORD,
+    ControlPcIsUnwound: BOOLEAN,
+    NonVolatileRegisters: PBYTE,
+}}
+pub type PDISPATCHER_CONTEXT = *mut DISPATCHER_CONTEXT;
+FN!{cdecl PEXCEPTION_FILTER(
+    ExceptionPointers: *mut EXCEPTION_POINTERS,
+    EstablisherFrame: DWORD64,
+) -> LONG}
+FN!{cdecl PTERMINATION_HANDLER(
+    AbnormalTermination: BOOLEAN,
+    EstablisherFrame: DWORD64,
+) -> ()}
+STRUCT!{struct KNONVOLATILE_CONTEXT_POINTERS {
+    X19: PDWORD64,
+    X20: PDWORD64,
+    X21: PDWORD64,
+    X22: PDWORD64,
+    X23: PDWORD64,
+    X24: PDWORD64,
+    X25: PDWORD64,
+    X26: PDWORD64,
+    X27: PDWORD64,
+    X28: PDWORD64,
+    Fp: PDWORD64,
+    Lr: PDWORD64,
+    D8: PDWORD64,
+    D9: PDWORD64,
+    D10: PDWORD64,
+    D11: PDWORD64,
+    D12: PDWORD64,
+    D13: PDWORD64,
+    D14: PDWORD64,
+    D15: PDWORD64,
+}}
+pub type PKNONVOLATILE_CONTEXT_POINTERS = *mut KNONVOLATILE_CONTEXT_POINTERS;
+} // IFDEF(aarch64)
 pub const WOW64_CONTEXT_i386: DWORD = 0x00010000;
 pub const WOW64_CONTEXT_i486: DWORD = 0x00010000;
 pub const WOW64_CONTEXT_CONTROL: DWORD = WOW64_CONTEXT_i386 | 0x00000001;
@@ -2125,7 +2309,7 @@ STRUCT!{struct ACL_SIZE_INFORMATION {
 pub type PACL_SIZE_INFORMATION = *mut ACL_SIZE_INFORMATION;
 pub const SECURITY_DESCRIPTOR_REVISION: DWORD = 1;
 pub const SECURITY_DESCRIPTOR_REVISION1: DWORD = 1;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 pub const SECURITY_DESCRIPTOR_MIN_LENGTH: usize = 40;
 #[cfg(target_arch = "x86")]
 pub const SECURITY_DESCRIPTOR_MIN_LENGTH: usize = 20;
@@ -5539,7 +5723,7 @@ pub type PIMAGE_OPTIONAL_HEADER64 = *mut IMAGE_OPTIONAL_HEADER64;
 pub const IMAGE_NT_OPTIONAL_HDR32_MAGIC: WORD = 0x10b;
 pub const IMAGE_NT_OPTIONAL_HDR64_MAGIC: WORD = 0x20b;
 pub const IMAGE_ROM_OPTIONAL_HDR_MAGIC: WORD = 0x107;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 pub type IMAGE_OPTIONAL_HEADER = IMAGE_OPTIONAL_HEADER64;
 pub type PIMAGE_OPTIONAL_HEADER = PIMAGE_OPTIONAL_HEADER64;
@@ -5568,7 +5752,7 @@ STRUCT!{struct IMAGE_ROM_HEADERS {
     OptionalHeader: IMAGE_ROM_OPTIONAL_HEADER,
 }}
 pub type PIMAGE_ROM_HEADERS = *mut IMAGE_ROM_HEADERS;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 pub type IMAGE_NT_HEADERS = IMAGE_NT_HEADERS64;
 pub type PIMAGE_NT_HEADERS = PIMAGE_NT_HEADERS64;
@@ -6334,7 +6518,7 @@ BITFIELD!{IMAGE_TLS_DIRECTORY32 Characteristics: DWORD [
     Reserved1 set_Reserved1[24..32],
 ]}
 pub type PIMAGE_TLS_DIRECTORY32 = *mut IMAGE_TLS_DIRECTORY32;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 pub const IMAGE_ORDINAL_FLAG: ULONGLONG = IMAGE_ORDINAL_FLAG64;
 #[inline]
@@ -6498,7 +6682,7 @@ STRUCT!{#[repr(packed)] struct IMAGE_DYNAMIC_RELOCATION64_V2 {
     Flags: DWORD,
 }}
 pub type PIMAGE_DYNAMIC_RELOCATION64_V2 = *mut IMAGE_DYNAMIC_RELOCATION64_V2;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 pub type IMAGE_DYNAMIC_RELOCATION = IMAGE_DYNAMIC_RELOCATION64;
 pub type PIMAGE_DYNAMIC_RELOCATION = PIMAGE_DYNAMIC_RELOCATION64;
@@ -6613,7 +6797,7 @@ STRUCT!{struct IMAGE_LOAD_CONFIG_DIRECTORY64 {
     EnclaveConfigurationPointer: ULONGLONG,
 }}
 pub type PIMAGE_LOAD_CONFIG_DIRECTORY64 = *mut IMAGE_LOAD_CONFIG_DIRECTORY64;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 pub type IMAGE_LOAD_CONFIG_DIRECTORY = IMAGE_LOAD_CONFIG_DIRECTORY64;
 pub type PIMAGE_LOAD_CONFIG_DIRECTORY = PIMAGE_LOAD_CONFIG_DIRECTORY64;
@@ -6742,14 +6926,24 @@ UNION!{union IMAGE_RUNTIME_FUNCTION_ENTRY_u {
     UnwindInfoAddress UnwindInfoAddress_mut: DWORD,
     UnwindData UnwindData_mut: DWORD,
 }}
-STRUCT!{struct IMAGE_RUNTIME_FUNCTION_ENTRY {
+STRUCT!{struct _IMAGE_RUNTIME_FUNCTION_ENTRY {
     BeginAddress: DWORD,
     EndAddress: DWORD,
     u: IMAGE_RUNTIME_FUNCTION_ENTRY_u,
 }}
-pub type PIMAGE_RUNTIME_FUNCTION_ENTRY = *mut IMAGE_RUNTIME_FUNCTION_ENTRY;
-pub type IMAGE_IA64_RUNTIME_FUNCTION_ENTRY = IMAGE_RUNTIME_FUNCTION_ENTRY;
-pub type PIMAGE_IA64_RUNTIME_FUNCTION_ENTRY = PIMAGE_RUNTIME_FUNCTION_ENTRY;
+type _PIMAGE_RUNTIME_FUNCTION_ENTRY = *mut _IMAGE_RUNTIME_FUNCTION_ENTRY;
+pub type IMAGE_IA64_RUNTIME_FUNCTION_ENTRY = _IMAGE_RUNTIME_FUNCTION_ENTRY;
+pub type PIMAGE_IA64_RUNTIME_FUNCTION_ENTRY = _PIMAGE_RUNTIME_FUNCTION_ENTRY;
+#[cfg(target_arch = "aarch64")]
+IFDEF!{
+pub type IMAGE_RUNTIME_FUNCTION_ENTRY = IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY;
+pub type PIMAGE_RUNTIME_FUNCTION_ENTRY = PIMAGE_ARM64_RUNTIME_FUNCTION_ENTRY;
+}
+#[cfg(not(target_arch = "aarch64"))]
+IFDEF!{
+pub type IMAGE_RUNTIME_FUNCTION_ENTRY = _IMAGE_RUNTIME_FUNCTION_ENTRY;
+pub type PIMAGE_RUNTIME_FUNCTION_ENTRY = _PIMAGE_RUNTIME_FUNCTION_ENTRY;
+}
 STRUCT!{struct IMAGE_DEBUG_DIRECTORY {
     Characteristics: DWORD,
     TimeDateStamp: DWORD,
@@ -6981,7 +7175,7 @@ extern "system" {
         ReturnValue: PVOID,
     );
 }
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 extern "system" {
     pub fn RtlAddFunctionTable(
         FunctionTable: PRUNTIME_FUNCTION,
@@ -7064,7 +7258,7 @@ STRUCT!{struct SLIST_ENTRY {
     Next: *mut SLIST_ENTRY,
 }}
 pub type PSLIST_ENTRY = *mut SLIST_ENTRY;
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 IFDEF!{
 STRUCT!{struct SLIST_HEADER_s {
     Alignment: ULONGLONG,

--- a/src/um/winnt.rs
+++ b/src/um/winnt.rs
@@ -23,7 +23,7 @@ IFDEF!{
 pub const MAX_NATURAL_ALIGNMENT: usize = 4;
 pub const MEMORY_ALLOCATION_ALIGNMENT: usize = 8;
 }
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 pub const MAX_NATURAL_ALIGNMENT: usize = 8;
 pub const MEMORY_ALLOCATION_ALIGNMENT: usize = 16;
@@ -115,7 +115,7 @@ STRUCT!{struct GROUP_AFFINITY {
 pub type PGROUP_AFFINITY = *mut GROUP_AFFINITY;
 #[cfg(target_arch = "x86")]
 pub const MAXIMUM_PROC_PER_GROUP: BYTE = 32;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub const MAXIMUM_PROC_PER_GROUP: BYTE = 64;
 pub const MAXIMUM_PROCESSORS: BYTE = MAXIMUM_PROC_PER_GROUP;
 pub type HANDLE = *mut c_void;
@@ -2309,7 +2309,7 @@ STRUCT!{struct ACL_SIZE_INFORMATION {
 pub type PACL_SIZE_INFORMATION = *mut ACL_SIZE_INFORMATION;
 pub const SECURITY_DESCRIPTOR_REVISION: DWORD = 1;
 pub const SECURITY_DESCRIPTOR_REVISION1: DWORD = 1;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 pub const SECURITY_DESCRIPTOR_MIN_LENGTH: usize = 40;
 #[cfg(target_arch = "x86")]
 pub const SECURITY_DESCRIPTOR_MIN_LENGTH: usize = 20;
@@ -5723,7 +5723,7 @@ pub type PIMAGE_OPTIONAL_HEADER64 = *mut IMAGE_OPTIONAL_HEADER64;
 pub const IMAGE_NT_OPTIONAL_HDR32_MAGIC: WORD = 0x10b;
 pub const IMAGE_NT_OPTIONAL_HDR64_MAGIC: WORD = 0x20b;
 pub const IMAGE_ROM_OPTIONAL_HDR_MAGIC: WORD = 0x107;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 pub type IMAGE_OPTIONAL_HEADER = IMAGE_OPTIONAL_HEADER64;
 pub type PIMAGE_OPTIONAL_HEADER = PIMAGE_OPTIONAL_HEADER64;
@@ -5752,7 +5752,7 @@ STRUCT!{struct IMAGE_ROM_HEADERS {
     OptionalHeader: IMAGE_ROM_OPTIONAL_HEADER,
 }}
 pub type PIMAGE_ROM_HEADERS = *mut IMAGE_ROM_HEADERS;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 pub type IMAGE_NT_HEADERS = IMAGE_NT_HEADERS64;
 pub type PIMAGE_NT_HEADERS = PIMAGE_NT_HEADERS64;
@@ -6518,7 +6518,7 @@ BITFIELD!{IMAGE_TLS_DIRECTORY32 Characteristics: DWORD [
     Reserved1 set_Reserved1[24..32],
 ]}
 pub type PIMAGE_TLS_DIRECTORY32 = *mut IMAGE_TLS_DIRECTORY32;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 pub const IMAGE_ORDINAL_FLAG: ULONGLONG = IMAGE_ORDINAL_FLAG64;
 #[inline]
@@ -6682,7 +6682,7 @@ STRUCT!{#[repr(packed)] struct IMAGE_DYNAMIC_RELOCATION64_V2 {
     Flags: DWORD,
 }}
 pub type PIMAGE_DYNAMIC_RELOCATION64_V2 = *mut IMAGE_DYNAMIC_RELOCATION64_V2;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 pub type IMAGE_DYNAMIC_RELOCATION = IMAGE_DYNAMIC_RELOCATION64;
 pub type PIMAGE_DYNAMIC_RELOCATION = PIMAGE_DYNAMIC_RELOCATION64;
@@ -6797,7 +6797,7 @@ STRUCT!{struct IMAGE_LOAD_CONFIG_DIRECTORY64 {
     EnclaveConfigurationPointer: ULONGLONG,
 }}
 pub type PIMAGE_LOAD_CONFIG_DIRECTORY64 = *mut IMAGE_LOAD_CONFIG_DIRECTORY64;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 pub type IMAGE_LOAD_CONFIG_DIRECTORY = IMAGE_LOAD_CONFIG_DIRECTORY64;
 pub type PIMAGE_LOAD_CONFIG_DIRECTORY = PIMAGE_LOAD_CONFIG_DIRECTORY64;
@@ -7175,7 +7175,7 @@ extern "system" {
         ReturnValue: PVOID,
     );
 }
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 extern "system" {
     pub fn RtlAddFunctionTable(
         FunctionTable: PRUNTIME_FUNCTION,
@@ -7258,7 +7258,7 @@ STRUCT!{struct SLIST_ENTRY {
     Next: *mut SLIST_ENTRY,
 }}
 pub type PSLIST_ENTRY = *mut SLIST_ENTRY;
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 IFDEF!{
 STRUCT!{struct SLIST_HEADER_s {
     Alignment: ULONGLONG,

--- a/src/um/winsock2.rs
+++ b/src/um/winsock2.rs
@@ -90,7 +90,7 @@ STRUCT!{struct servent {
     s_port: c_short,
     s_proto: *mut c_char,
 }}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 STRUCT!{struct servent {
     s_name: *mut c_char,
     s_aliases: *mut *mut c_char,
@@ -143,7 +143,7 @@ STRUCT!{struct WSADATA {
     iMaxUdpDg: c_ushort,
     lpVendorInfo: *mut c_char,
 }}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 STRUCT!{struct WSADATA {
     wVersion: WORD,
     wHighVersion: WORD,

--- a/src/um/winsock2.rs
+++ b/src/um/winsock2.rs
@@ -90,7 +90,7 @@ STRUCT!{struct servent {
     s_port: c_short,
     s_proto: *mut c_char,
 }}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 STRUCT!{struct servent {
     s_name: *mut c_char,
     s_aliases: *mut *mut c_char,
@@ -143,7 +143,7 @@ STRUCT!{struct WSADATA {
     iMaxUdpDg: c_ushort,
     lpVendorInfo: *mut c_char,
 }}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 STRUCT!{struct WSADATA {
     wVersion: WORD,
     wHighVersion: WORD,

--- a/src/um/winuser.rs
+++ b/src/um/winuser.rs
@@ -9,7 +9,7 @@ use ctypes::{c_int, c_long, c_short, c_uint};
 use shared::basetsd::{
     DWORD_PTR, INT32, INT_PTR, PDWORD_PTR, UINT16, UINT32, UINT64, UINT_PTR, ULONG_PTR,
 };
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use shared::basetsd::LONG_PTR;
 use shared::guiddef::{GUID, LPCGUID};
 use shared::minwindef::{
@@ -4962,23 +4962,23 @@ extern "system" {
         nIndex: c_int,
         dwNewLong: LONG,
     ) -> LONG;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn GetWindowLongPtrA(
         hWnd: HWND,
         nIndex: c_int,
     ) -> LONG_PTR;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn GetWindowLongPtrW(
         hWnd: HWND,
         nIndex: c_int,
     ) -> LONG_PTR;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn SetWindowLongPtrA(
         hWnd: HWND,
         nIndex: c_int,
         dwNewLong: LONG_PTR,
     ) -> LONG_PTR;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn SetWindowLongPtrW(
         hWnd: HWND,
         nIndex: c_int,
@@ -5021,23 +5021,23 @@ extern "system" {
         nIndex: c_int,
         dwNewLong: LONG,
     ) -> DWORD;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn GetClassLongPtrA(
         hWnd: HWND,
         nIndex: c_int,
     ) -> ULONG_PTR;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn GetClassLongPtrW(
         hWnd: HWND,
         nIndex: c_int,
     ) -> ULONG_PTR;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn SetClassLongPtrA(
         hWnd: HWND,
         nIndex: c_int,
         dwNewLong: LONG_PTR,
     ) -> ULONG_PTR;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn SetClassLongPtrW(
         hWnd: HWND,
         nIndex: c_int,

--- a/src/um/winuser.rs
+++ b/src/um/winuser.rs
@@ -9,7 +9,7 @@ use ctypes::{c_int, c_long, c_short, c_uint};
 use shared::basetsd::{
     DWORD_PTR, INT32, INT_PTR, PDWORD_PTR, UINT16, UINT32, UINT64, UINT_PTR, ULONG_PTR,
 };
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 use shared::basetsd::LONG_PTR;
 use shared::guiddef::{GUID, LPCGUID};
 use shared::minwindef::{
@@ -4962,23 +4962,23 @@ extern "system" {
         nIndex: c_int,
         dwNewLong: LONG,
     ) -> LONG;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn GetWindowLongPtrA(
         hWnd: HWND,
         nIndex: c_int,
     ) -> LONG_PTR;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn GetWindowLongPtrW(
         hWnd: HWND,
         nIndex: c_int,
     ) -> LONG_PTR;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn SetWindowLongPtrA(
         hWnd: HWND,
         nIndex: c_int,
         dwNewLong: LONG_PTR,
     ) -> LONG_PTR;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn SetWindowLongPtrW(
         hWnd: HWND,
         nIndex: c_int,
@@ -5021,23 +5021,23 @@ extern "system" {
         nIndex: c_int,
         dwNewLong: LONG,
     ) -> DWORD;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn GetClassLongPtrA(
         hWnd: HWND,
         nIndex: c_int,
     ) -> ULONG_PTR;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn GetClassLongPtrW(
         hWnd: HWND,
         nIndex: c_int,
     ) -> ULONG_PTR;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn SetClassLongPtrA(
         hWnd: HWND,
         nIndex: c_int,
         dwNewLong: LONG_PTR,
     ) -> ULONG_PTR;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn SetClassLongPtrW(
         hWnd: HWND,
         nIndex: c_int,

--- a/src/um/ws2spi.rs
+++ b/src/um/ws2spi.rs
@@ -20,7 +20,7 @@ use um::winsock2::{
     LPWSAOVERLAPPED_COMPLETION_ROUTINE, LPWSAPROTOCOL_INFOW, LPWSAQUERYSET2W, LPWSAQUERYSETW,
     LPWSASERVICECLASSINFOW, SOCKET, WSAESETSERVICEOP, WSAEVENT, fd_set, timeval,
 };
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use um::winsock2::{LPWSANAMESPACE_INFOEXW, LPWSANAMESPACE_INFOW};
 use vc::vcruntime::size_t;
 pub const WSPDESCRIPTION_LEN: usize = 255;
@@ -427,7 +427,7 @@ FN!{stdcall LPWSCENUMPROTOCOLS(
     lpErrno: LPINT,
 ) -> c_int}
 extern "system" {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCEnumProtocols32(
         lpiProtocols: LPINT,
         lpProtocolBuffer: LPWSAPROTOCOL_INFOW,
@@ -444,7 +444,7 @@ FN!{stdcall LPWSCDEINSTALLPROVIDER(
     lpErrno: LPINT,
 ) -> c_int}
 extern "system" {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCDeinstallProvider32(
         lpProviderId: LPGUID,
         lpErrno: LPINT,
@@ -465,7 +465,7 @@ FN!{stdcall LPWSCINSTALLPROVIDER(
     lpErrno: LPINT,
 ) -> c_int}
 extern "system" {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCInstallProvider64_32(
         lpProviderId: LPGUID,
         lpszProviderDllPath: *const WCHAR,
@@ -487,7 +487,7 @@ FN!{stdcall LPWSCGETPROVIDERPATH(
     lpErrno: LPINT,
 ) -> c_int}
 extern "system" {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCGetProviderPath32(
         lpProviderId: LPGUID,
         lpszProviderDllPath: *mut WCHAR,
@@ -509,7 +509,7 @@ FN!{stdcall LPWSCUPDATEPROVIDER(
     dwNumberOfEntries: DWORD,
     lpErrno: LPINT,
 ) -> c_int}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 extern "system" {
     pub fn WSCUpdateProvider32(
         lpProviderId: LPGUID,
@@ -553,7 +553,7 @@ extern "system" {
         Flags: DWORD,
         lpErrno: LPINT,
     ) -> c_int;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCSetProviderInfo32(
         lpProviderId: LPGUID,
         InfoType: WSC_PROVIDER_INFO_TYPE,
@@ -562,7 +562,7 @@ extern "system" {
         Flags: DWORD,
         lpErrno: LPINT,
     ) -> c_int;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCGetProviderInfo32(
         lpProviderId: LPGUID,
         InfoType: WSC_PROVIDER_INFO_TYPE,
@@ -665,12 +665,12 @@ extern "system" {
         lpThreadId: LPWSATHREADID,
         lpErrno: LPINT,
     ) -> c_int;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCEnumNameSpaceProviders32(
         lpdwBufferLength: LPDWORD,
         lpnspBuffer: LPWSANAMESPACE_INFOW,
     ) -> INT;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCEnumNameSpaceProvidersEx32(
         lpdwBufferLength: LPDWORD,
         lpnspBuffer: LPWSANAMESPACE_INFOEXW,
@@ -691,7 +691,7 @@ FN!{stdcall LPWSCINSTALLNAMESPACE(
     lpProviderId: LPGUID,
 ) -> INT}
 extern "system" {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCInstallNameSpace32(
         lpszIdentifier: LPWSTR,
         lpszPathName: LPWSTR,
@@ -715,7 +715,7 @@ extern "system" {
         lpProviderId: LPGUID,
         lpProviderSpecific: LPBLOB,
     ) -> INT;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCInstallNameSpaceEx32(
         lpszIdentifier: LPWSTR,
         lpszPathName: LPWSTR,
@@ -724,7 +724,7 @@ extern "system" {
         lpProviderId: LPGUID,
         lpProviderSpecific: LPBLOB,
     ) -> INT;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCUnInstallNameSpace32(
         lpProviderId: LPGUID,
     ) -> INT;
@@ -738,12 +738,12 @@ FN!{stdcall LPWSCENABLENSPROVIDER(
     fEnable: BOOL,
 ) -> INT}
 extern "system" {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCEnableNSProvider32(
         lpProviderId: LPGUID,
         fEnable: BOOL,
     ) -> INT;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn WSCInstallProviderAndChains64_32(
         lpProviderId: LPGUID,
         lpszProviderDllPath: LPWSTR,

--- a/src/um/ws2spi.rs
+++ b/src/um/ws2spi.rs
@@ -20,7 +20,7 @@ use um::winsock2::{
     LPWSAOVERLAPPED_COMPLETION_ROUTINE, LPWSAPROTOCOL_INFOW, LPWSAQUERYSET2W, LPWSAQUERYSETW,
     LPWSASERVICECLASSINFOW, SOCKET, WSAESETSERVICEOP, WSAEVENT, fd_set, timeval,
 };
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 use um::winsock2::{LPWSANAMESPACE_INFOEXW, LPWSANAMESPACE_INFOW};
 use vc::vcruntime::size_t;
 pub const WSPDESCRIPTION_LEN: usize = 255;
@@ -427,7 +427,7 @@ FN!{stdcall LPWSCENUMPROTOCOLS(
     lpErrno: LPINT,
 ) -> c_int}
 extern "system" {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCEnumProtocols32(
         lpiProtocols: LPINT,
         lpProtocolBuffer: LPWSAPROTOCOL_INFOW,
@@ -444,7 +444,7 @@ FN!{stdcall LPWSCDEINSTALLPROVIDER(
     lpErrno: LPINT,
 ) -> c_int}
 extern "system" {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCDeinstallProvider32(
         lpProviderId: LPGUID,
         lpErrno: LPINT,
@@ -465,7 +465,7 @@ FN!{stdcall LPWSCINSTALLPROVIDER(
     lpErrno: LPINT,
 ) -> c_int}
 extern "system" {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCInstallProvider64_32(
         lpProviderId: LPGUID,
         lpszProviderDllPath: *const WCHAR,
@@ -487,7 +487,7 @@ FN!{stdcall LPWSCGETPROVIDERPATH(
     lpErrno: LPINT,
 ) -> c_int}
 extern "system" {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCGetProviderPath32(
         lpProviderId: LPGUID,
         lpszProviderDllPath: *mut WCHAR,
@@ -509,7 +509,7 @@ FN!{stdcall LPWSCUPDATEPROVIDER(
     dwNumberOfEntries: DWORD,
     lpErrno: LPINT,
 ) -> c_int}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 extern "system" {
     pub fn WSCUpdateProvider32(
         lpProviderId: LPGUID,
@@ -553,7 +553,7 @@ extern "system" {
         Flags: DWORD,
         lpErrno: LPINT,
     ) -> c_int;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCSetProviderInfo32(
         lpProviderId: LPGUID,
         InfoType: WSC_PROVIDER_INFO_TYPE,
@@ -562,7 +562,7 @@ extern "system" {
         Flags: DWORD,
         lpErrno: LPINT,
     ) -> c_int;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCGetProviderInfo32(
         lpProviderId: LPGUID,
         InfoType: WSC_PROVIDER_INFO_TYPE,
@@ -665,12 +665,12 @@ extern "system" {
         lpThreadId: LPWSATHREADID,
         lpErrno: LPINT,
     ) -> c_int;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCEnumNameSpaceProviders32(
         lpdwBufferLength: LPDWORD,
         lpnspBuffer: LPWSANAMESPACE_INFOW,
     ) -> INT;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCEnumNameSpaceProvidersEx32(
         lpdwBufferLength: LPDWORD,
         lpnspBuffer: LPWSANAMESPACE_INFOEXW,
@@ -691,7 +691,7 @@ FN!{stdcall LPWSCINSTALLNAMESPACE(
     lpProviderId: LPGUID,
 ) -> INT}
 extern "system" {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCInstallNameSpace32(
         lpszIdentifier: LPWSTR,
         lpszPathName: LPWSTR,
@@ -715,7 +715,7 @@ extern "system" {
         lpProviderId: LPGUID,
         lpProviderSpecific: LPBLOB,
     ) -> INT;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCInstallNameSpaceEx32(
         lpszIdentifier: LPWSTR,
         lpszPathName: LPWSTR,
@@ -724,7 +724,7 @@ extern "system" {
         lpProviderId: LPGUID,
         lpProviderSpecific: LPBLOB,
     ) -> INT;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCUnInstallNameSpace32(
         lpProviderId: LPGUID,
     ) -> INT;
@@ -738,12 +738,12 @@ FN!{stdcall LPWSCENABLENSPROVIDER(
     fEnable: BOOL,
 ) -> INT}
 extern "system" {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCEnableNSProvider32(
         lpProviderId: LPGUID,
         fEnable: BOOL,
     ) -> INT;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(target_pointer_width = "64")]
     pub fn WSCInstallProviderAndChains64_32(
         lpProviderId: LPGUID,
         lpszProviderDllPath: LPWSTR,

--- a/src/winrt/hstring.rs
+++ b/src/winrt/hstring.rs
@@ -14,7 +14,7 @@ UNION!{union HSTRING_HEADER_Reserved {
     Reserved1 Reserved1_mut: PVOID,
     Reserved2 Reserved2_mut: [c_char; 20],
 }}
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 UNION!{union HSTRING_HEADER_Reserved {
     [u64; 3],
     Reserved1 Reserved1_mut: PVOID,

--- a/src/winrt/hstring.rs
+++ b/src/winrt/hstring.rs
@@ -14,7 +14,7 @@ UNION!{union HSTRING_HEADER_Reserved {
     Reserved1 Reserved1_mut: PVOID,
     Reserved2 Reserved2_mut: [c_char; 20],
 }}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(target_pointer_width = "64")]
 UNION!{union HSTRING_HEADER_Reserved {
     [u64; 3],
     Reserved1 Reserved1_mut: PVOID,


### PR DESCRIPTION
A lot of this is just finding places where we were conditionalizing on `target_arch = "x86_64"` and using a `target_pointer_width` test instead.  The real interesting parts are in `winnt.rs`.

I'm not sure of a good way to test this.  Everything builds OK on `x86_64-pc-windows-msvc`, so I haven't broken anything.  Unfortunately, the `aarch64-pc-windows-msvc` target is in a bit of a rough state (see rust-lang/rust#53864), and I can't build `libstd` for that target locally.  I did try making the `aarch64` definitions compile on `x86_64` (and vice versa) in `winnt.rs`, and building with that change seemed to be OK.