### PR TITLE
Added ITypeComp, DESCKIND, BINDPTR definitions, and size/alignment te…

### DIFF
--- a/src/um/oaidl.rs
+++ b/src/um/oaidl.rs
@@ -700,9 +700,9 @@ ENUM!{enum DESCKIND {
 }}
 UNION!{union BINDPTR {
     [usize; 1],
-    Lpfuncdesc Lpfuncdesc_mut: LPFUNCDESC, 
-    Lpvardesc Lpvardesc_mut: LPVARDESC, 
-    Lptcomp Lptcomp_mut: LPTYPECOMP,
+    lpfuncdesc lpfuncdesc_mut: *mut FUNCDESC, 
+    lpvardesc lpvardesc_mut: *mut VARDESC, 
+    lptcomp lptcomp_mut: *mut ITypeComp,
 }}
 pub type LPBINDPTR = *mut BINDPTR;
 RIDL!{#[uuid(0x00020403, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46)]

--- a/src/um/oaidl.rs
+++ b/src/um/oaidl.rs
@@ -699,7 +699,7 @@ ENUM!{enum DESCKIND {
     DESCKIND_MAX = DESCKIND_IMPLICITAPPOBJ + 1,
 }}
 UNION!{union BINDPTR {
-    [u32; 1] [u64; 1],
+    [usize; 1],
     Lpfuncdesc Lpfuncdesc_mut: LPFUNCDESC, 
     Lpvardesc Lpvardesc_mut: LPVARDESC, 
     Lptcomp Lptcomp_mut: LPTYPECOMP,

--- a/src/um/oaidl.rs
+++ b/src/um/oaidl.rs
@@ -689,7 +689,39 @@ interface IRecordInfo(IRecordInfoVtbl): IUnknown(IUnknownVtbl){
         pvRecord: PVOID,
     ) -> HRESULT,
 }}
-pub enum ITypeComp {} // FIXME
+pub type LPTYPECOMP = *mut ITypeComp;
+ENUM!{enum DESCKIND {
+    DESCKIND_NONE = 0, 
+    DESCKIND_FUNCDESC = DESCKIND_NONE + 1, 
+    DESCKIND_VARDESC = DESCKIND_FUNCDESC + 1, 
+    DESCKIND_TYPECOMP = DESCKIND_VARDESC + 1, 
+    DESCKIND_IMPLICITAPPOBJ = DESCKIND_TYPECOMP + 1, 
+    DESCKIND_MAX = DESCKIND_IMPLICITAPPOBJ + 1,
+}}
+UNION!{union BINDPTR {
+    [u32; 1] [u64; 1],
+    Lpfuncdesc Lpfuncdesc_mut: LPFUNCDESC, 
+    Lpvardesc Lpvardesc_mut: LPVARDESC, 
+    Lptcomp Lptcomp_mut: LPTYPECOMP,
+}}
+pub type LPBINDPTR = *mut BINDPTR;
+RIDL!{#[uuid(0x00020403, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46)]
+interface ITypeComp(ITypeCompVtbl): IUnknown(IUnknownVtbl) {
+    fn Bind(
+        szName: LPOLESTR, 
+        lHashVal: ULONG, 
+        wFlags: WORD, 
+        ppTInfo: *mut *mut ITypeInfo, 
+        pDescKind: *mut DESCKIND, 
+        pBindPtr: *mut BINDPTR, 
+    ) -> HRESULT, 
+    fn BindType(
+        szName: LPOLESTR, 
+        lHashVal: ULONG, 
+        ppTInfo: *mut *mut ITypeInfo, 
+        ppTComp: *mut *mut ITypeComp,
+    ) -> HRESULT,
+}}
 ENUM!{enum SYSKIND {
     SYS_WIN16 = 0,
     SYS_WIN32,

--- a/tests/structs_x86.rs
+++ b/tests/structs_x86.rs
@@ -4746,6 +4746,14 @@ fn um_oaidl() {
     assert_eq!(align_of::<CUSTDATA>(), 4);
     assert_eq!(size_of::<TLIBATTR>(), 32);
     assert_eq!(align_of::<TLIBATTR>(), 4);
+    assert_eq!(size_of::<IRecordInfo>(), 4);
+    assert_eq!(align_of::<IRecordInfo>(), 4);
+    assert_eq!(size_of::<DESCKIND>(), 4);
+    assert_eq!(align_of::<DESCKIND>(), 4);
+    assert_eq!(size_of::<BINDPTR>(), 4);
+    assert_eq!(align_of::<BINDPTR>(), 4);
+    assert_eq!(size_of::<ITypeComp>(), 4);
+    assert_eq!(align_of::<ITypeComp>(), 4);
 }
 #[cfg(feature = "objidl")] #[test]
 fn um_objidl() {

--- a/tests/structs_x86.rs
+++ b/tests/structs_x86.rs
@@ -4746,14 +4746,8 @@ fn um_oaidl() {
     assert_eq!(align_of::<CUSTDATA>(), 4);
     assert_eq!(size_of::<TLIBATTR>(), 32);
     assert_eq!(align_of::<TLIBATTR>(), 4);
-    assert_eq!(size_of::<IRecordInfo>(), 4);
-    assert_eq!(align_of::<IRecordInfo>(), 4);
-    assert_eq!(size_of::<DESCKIND>(), 4);
-    assert_eq!(align_of::<DESCKIND>(), 4);
     assert_eq!(size_of::<BINDPTR>(), 4);
     assert_eq!(align_of::<BINDPTR>(), 4);
-    assert_eq!(size_of::<ITypeComp>(), 4);
-    assert_eq!(align_of::<ITypeComp>(), 4);
 }
 #[cfg(feature = "objidl")] #[test]
 fn um_objidl() {

--- a/tests/structs_x86_64.rs
+++ b/tests/structs_x86_64.rs
@@ -4771,14 +4771,8 @@ fn um_oaidl() {
     assert_eq!(align_of::<CUSTDATA>(), 8);
     assert_eq!(size_of::<TLIBATTR>(), 32);
     assert_eq!(align_of::<TLIBATTR>(), 4);
-    assert_eq!(size_of::<IRecordInfo>(), 8);
-    assert_eq!(align_of::<IRecordInfo>(), 8);
-    assert_eq!(size_of::<DESCKIND>(), 4);
-    assert_eq!(align_of::<DESCKIND>(), 4);
     assert_eq!(size_of::<BINDPTR>(), 8);
     assert_eq!(align_of::<BINDPTR>(), 8);
-    assert_eq!(size_of::<ITypeComp>(), 8);
-    assert_eq!(align_of::<ITypeComp>(), 8);
 }
 #[cfg(feature = "objidl")] #[test]
 fn um_objidl() {

--- a/tests/structs_x86_64.rs
+++ b/tests/structs_x86_64.rs
@@ -4771,6 +4771,14 @@ fn um_oaidl() {
     assert_eq!(align_of::<CUSTDATA>(), 8);
     assert_eq!(size_of::<TLIBATTR>(), 32);
     assert_eq!(align_of::<TLIBATTR>(), 4);
+    assert_eq!(size_of::<IRecordInfo>(), 8);
+    assert_eq!(align_of::<IRecordInfo>(), 8);
+    assert_eq!(size_of::<DESCKIND>(), 4);
+    assert_eq!(align_of::<DESCKIND>(), 4);
+    assert_eq!(size_of::<BINDPTR>(), 8);
+    assert_eq!(align_of::<BINDPTR>(), 8);
+    assert_eq!(size_of::<ITypeComp>(), 8);
+    assert_eq!(align_of::<ITypeComp>(), 8);
 }
 #[cfg(feature = "objidl")] #[test]
 fn um_objidl() {


### PR DESCRIPTION
Added ITypeComp, DESCKIND, and BINDPTR definitions to oaidl.rs. 
Added size/alignment tests for new definitions(and IRecordInfo that I added previously.)

Used WinSDK header from path:  WindowsKits\10\Include\10.0.17134.0\um\OAIdl.h