### PR TITLE
Fix the method declaration for um::wincodec::IWICBitmapSource::CopyPa…

### DIFF
--- a/src/um/wincodec.rs
+++ b/src/um/wincodec.rs
@@ -698,7 +698,7 @@ interface IWICBitmapSource(IWICBitmapSourceVtbl): IUnknown(IUnknownVtbl) {
         pDpiY: *mut c_double,
     ) -> HRESULT,
     fn CopyPalette(
-        pIPalette: *const IWICPalette,
+        pIPalette: *mut IWICPalette,
     ) -> HRESULT,
     fn CopyPixels(
         prc: *const WICRect,


### PR DESCRIPTION
…lette

This method was declared in wincodec as taking a *const IWICPalette, but according to the
official documentation and headers this should take a *mut IWICPalette.
https://docs.microsoft.com/en-us/windows/desktop/api/wincodec/nf-wincodec-iwicbitmapsource-copypalette

Unfortunately I think this could be a breaking change for anyone using `wincodec` :( so it will probably have to wait for 0.4