### PR TITLE
Reconfigure appveyor.yml to enable aarch64-pc-windows-msvc target

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
   - TARGET: nightly-x86_64-pc-windows-msvc
+  - TARGET: nightly-aarch64-pc-windows-msvc
   - TARGET: nightly-i686-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-gnu
   - TARGET: nightly-i686-pc-windows-gnu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 environment:
+  channel: nightly
+  host: x86_64-pc-windows-msvc
   matrix:
   - TARGET: nightly-x86_64-pc-windows-msvc
   - TARGET: nightly-aarch64-pc-windows-msvc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,8 @@ matrix:
     - target: aarch64-pc-windows-msvc
     
 cache:
- - C:\Users\appveyor\.rustup
- - C:\Users\appveyor\.rustc
- - C:\Users\appveyor\.cargo
+ - C:\projects\winapi-rs
+ - C:\Users\appveyor
 
 install:
   - ps: if (ls -r . -fi "*.rs" | sls "`t") { throw "Found tab character" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,7 @@ environment:
     channel: stable
   - target: x86_64-pc-windows-gnu
     host: x86_64-pc-windows-gnu
-    channel: none
-    version: 1.6.0
+    channel: 1.6.0
 matrix:
   allow_failures:
     - target: aarch64-pc-windows-msvc
@@ -29,7 +28,6 @@ install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
-  - rustup install %version%
   - rustup target add %target%
   - rustc -vV
   - cargo -vV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,18 @@
-image: Visual Studio 2017
-
 environment:
   channel: nightly
   host: x86_64-pc-windows-msvc
   matrix:
   - TARGET: x86_64-pc-windows-msvc
+    image: Visual Studio 2017
   - TARGET: aarch64-pc-windows-msvc
+    image: Visual Studio 2017
   - TARGET: i686-pc-windows-msvc
+    image: Visual Studio 2017
   - TARGET: x86_64-pc-windows-gnu
+    image: Ubuntu1804
   - TARGET: i686-pc-windows-gnu
+    image: Ubuntu1804
+
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,6 @@ environment:
 matrix:
   allow_failures:
     - target: aarch64-pc-windows-msvc
-    
-cache:
- - C:\projects\winapi-rs
- - C:\Users\appveyor
 
 install:
   - ps: if (ls -r . -fi "*.rs" | sls "`t") { throw "Found tab character" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2017
+
 environment:
   channel: nightly
   host: x86_64-pc-windows-msvc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,15 +38,11 @@ build_script:
   - cargo build --release --target=%target%
   - cargo build --target=%target% --features "everything debug impl-default"
 
-after_build:
-  - dir *.exe /s /b | find ^"temp^" /v /i | findstr /e .exe
-  - dir \*.exe /s /b | find ^"temp^" /v /i | findstr /e .exe
-
-# test_script:
-#   - cargo test --target=%target% --features "everything debug impl-default"
+test_script:
+  - cargo test --target=%target% --features "everything debug impl-default"
   
 artifacts:
-  - path: target\$(target)\release\*.exe
+  - path: target\$(target)\release\**\*.exe
     name: winapi-rs-$(target)
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,9 @@ environment:
   - TARGET: nightly-i686-pc-windows-gnu
   - TARGET: 1.6.0-x86_64-pc-windows-gnu
 install:
-  - ps: if (ls -r . -fi "*.rs" | sls "`t") { throw "Found tab character" }
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe" -FileName "rust-install.exe"
-  - ps: .\rust-install.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null
-  - ps: $env:PATH="$env:PATH;C:\rust\bin"
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain %channel% --default-host %host%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
   - rustc -vV
   - cargo -vV
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
   - rustc -vV
   - cargo -vV
+  - rustup target add %TARGET%
 build_script:
   - cargo build
   - cargo build --features "everything debug impl-default"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,19 @@ environment:
   matrix:
   - target: x86_64-pc-windows-msvc
     host: x86_64-pc-windows-msvc
-    channel: stable
+    channel: nightly
   - target: aarch64-pc-windows-msvc
     host: x86_64-pc-windows-msvc
     channel: nightly
   - target: i686-pc-windows-msvc
     host: i686-pc-windows-msvc
-    channel: stable
+    channel: nightly
   - target: x86_64-pc-windows-gnu
     host: x86_64-pc-windows-gnu
-    channel: stable
+    channel: nightly
   - target: i686-pc-windows-gnu
     host: i686-pc-windows-gnu
-    channel: stable
+    channel: nightly
   - target: x86_64-pc-windows-gnu
     host: x86_64-pc-windows-gnu
     channel: 1.6.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,19 @@ environment:
   channel: nightly
   matrix:
   - TARGET: x86_64-pc-windows-msvc
+    HOST: x86_64-pc-windows-msvc
   - TARGET: aarch64-pc-windows-msvc
+    HOST: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
+    HOST: i686-pc-windows-msvc
   - TARGET: x86_64-pc-windows-gnu
+    HOST: x86_64-pc-windows-gnu
   - TARGET: i686-pc-windows-gnu
+    HOST: i686-pc-windows-gnu
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init -yv --default-toolchain %channel% --default-host %TARGET%
+  - rustup-init -yv --default-toolchain %channel% --default-host %HOST%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
   - ps: $Env:PKG_CONFIG_ALLOW_CROSS=1
   - rustc -vV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ matrix:
     - target: aarch64-pc-windows-msvc
     
 cache:
- - rustup
- - rustc
- - cargo
+ - C:\Users\appveyor\.rustup
+ - C:\Users\appveyor\.rustc
+ - C:\Users\appveyor\.cargo
 
 install:
   - ps: if (ls -r . -fi "*.rs" | sls "`t") { throw "Found tab character" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,14 +38,14 @@ build_script:
   - cargo build --release --target=%target%
 #  - cargo build --target=%target% --features "everything debug impl-default"
 
-# test_script:
-#   - cargo test --target=%target% --features "everything debug impl-default"
+#test_script:
+#  - cargo test --target=%target% --features "everything debug impl-default"
 
-after_build:
-  - dir *.exe /s /b | find ^"temp^" /v /i | findstr /e .exe
+#after_build:
+#  - dir *.exe /s /b | find ^"temp^" /v /i | findstr /e .exe
 
 artifacts:
-  - path: target\$(target)\release\**\*.exe
+  - path: target\release\**\*.exe
     name: winapi-rs-$(target)
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,13 +35,14 @@ install:
 
 build_script:
   - cargo build --target=%target%
+  - cargo build --release --target=%target%
   - cargo build --target=%target% --features "everything debug impl-default"
 
 test_script:
   - cargo test --target=%target% --features "everything debug impl-default"
   
 artifacts:
-  - path: target\$(target)\debug\*.exe
+  - path: target\$(target)\release\*.exe
     name: winapi-rs-$(target)
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,34 +1,45 @@
 image: Visual Studio 2017
 
 environment:
-  channel: nightly
   matrix:
-  - TARGET: x86_64-pc-windows-msvc
-    HOST: x86_64-pc-windows-msvc
-  - TARGET: aarch64-pc-windows-msvc
-    HOST: x86_64-pc-windows-msvc
-  - TARGET: i686-pc-windows-msvc
-    HOST: i686-pc-windows-msvc
-  - TARGET: x86_64-pc-windows-gnu
-    HOST: x86_64-pc-windows-gnu
-  - TARGET: i686-pc-windows-gnu
-    HOST: i686-pc-windows-gnu
+  - target: x86_64-pc-windows-msvc
+    host: x86_64-pc-windows-msvc
+    channel: stable
+  - target: aarch64-pc-windows-msvc
+    host: x86_64-pc-windows-msvc
+    channel: nightly
+  - target: i686-pc-windows-msvc
+    host: i686-pc-windows-msvc
+    channel: stable
+  - target: x86_64-pc-windows-gnu
+    host: x86_64-pc-windows-gnu
+    channel: stable
+  - target: i686-pc-windows-gnu
+    host: i686-pc-windows-gnu
+    channel: stable
+  - target: x86_64-pc-windows-gnu
+    host: x86_64-pc-windows-gnu
+    channel: none
+    version: 1.6.0
+matrix:
+  allow_failures:
+    - target: aarch64-pc-windows-msvc
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init -yv --default-toolchain %channel% --default-host %HOST%
+  - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
-  - ps: $Env:PKG_CONFIG_ALLOW_CROSS=1
+  - rustup install %version%
+  - rustup target add %target%
   - rustc -vV
   - cargo -vV
-  - rustup target add %TARGET%
 
 build_script:
-  - cargo build --target=%TARGET%
-  - cargo build --target=%TARGET% --features "everything debug impl-default"
+  - cargo build --target=%target%
+  - cargo build --target=%target% --features "everything debug impl-default"
 
 test_script:
-  - cargo test --target=%TARGET% --features "everything debug impl-default"
+  - cargo test --target=%target% --features "everything debug impl-default"
 
 notifications:
   - provider: Webhook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,11 +36,14 @@ install:
 build_script:
   - cargo build --target=%target%
   - cargo build --release --target=%target%
-  - cargo build --target=%target% --features "everything debug impl-default"
+#  - cargo build --target=%target% --features "everything debug impl-default"
 
-test_script:
-  - cargo test --target=%target% --features "everything debug impl-default"
-  
+# test_script:
+#   - cargo test --target=%target% --features "everything debug impl-default"
+
+after_build:
+  - dir *.exe /s /b | find ^"temp^" /v /i | findstr /e .exe
+
 artifacts:
   - path: target\$(target)\release\**\*.exe
     name: winapi-rs-$(target)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init -yv --default-toolchain %channel% --default-host %host%
+  - rustup-init -yv --default-toolchain %channel%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
   - ps: $Env:PKG_CONFIG_ALLOW_CROSS=1
   - rustc -vV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
+  - ps: $Env:PKG_CONFIG_ALLOW_CROSS=1
   - rustc -vV
   - cargo -vV
   - rustup target add %TARGET%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,30 @@
+image: Visual Studio 2017
+
 environment:
   channel: nightly
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    image: Visual Studio 2017
   - TARGET: aarch64-pc-windows-msvc
-    image: Visual Studio 2017
   - TARGET: i686-pc-windows-msvc
-    image: Visual Studio 2017
   - TARGET: x86_64-pc-windows-gnu
-    image: Ubuntu1804
   - TARGET: i686-pc-windows-gnu
-    image: Ubuntu1804
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init -yv --default-toolchain %channel%
+  - rustup-init -yv --default-toolchain %channel% --default-host %TARGET%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
   - ps: $Env:PKG_CONFIG_ALLOW_CROSS=1
   - rustc -vV
   - cargo -vV
   - rustup target add %TARGET%
+
 build_script:
   - cargo build --target=%TARGET%
   - cargo build --target=%TARGET% --features "everything debug impl-default"
+
 test_script:
   - cargo test --target=%TARGET% --features "everything debug impl-default"
+
 notifications:
   - provider: Webhook
     url: https://webhooks.gitter.im/e/d3d6703d143c888f0a8a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ matrix:
     - target: aarch64-pc-windows-msvc
 
 install:
+  - ps: if (ls -r . -fi "*.rs" | sls "`t") { throw "Found tab character" }
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,11 @@ environment:
   channel: nightly
   host: x86_64-pc-windows-msvc
   matrix:
-  - TARGET: nightly-x86_64-pc-windows-msvc
-  - TARGET: nightly-aarch64-pc-windows-msvc
-  - TARGET: nightly-i686-pc-windows-msvc
-  - TARGET: nightly-x86_64-pc-windows-gnu
-  - TARGET: nightly-i686-pc-windows-gnu
-  - TARGET: 1.6.0-x86_64-pc-windows-gnu
+  - TARGET: x86_64-pc-windows-msvc
+  - TARGET: aarch64-pc-windows-msvc
+  - TARGET: i686-pc-windows-msvc
+  - TARGET: x86_64-pc-windows-gnu
+  - TARGET: i686-pc-windows-gnu
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
@@ -16,10 +15,10 @@ install:
   - cargo -vV
   - rustup target add %TARGET%
 build_script:
-  - cargo build
-  - cargo build --features "everything debug impl-default"
+  - cargo build --target=%TARGET%
+  - cargo build --target=%TARGET% --features "everything debug impl-default"
 test_script:
-  - cargo test --features "everything debug impl-default"
+  - cargo test --target=%TARGET% --features "everything debug impl-default"
 notifications:
   - provider: Webhook
     url: https://webhooks.gitter.im/e/d3d6703d143c888f0a8a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
-  - rustup target add %target%
+  - if NOT %host% == %target% rustup target add %target%
   - rustc -vV
   - cargo -vV
 
@@ -38,6 +38,10 @@ build_script:
 
 test_script:
   - cargo test --target=%target% --features "everything debug impl-default"
+  
+artifacts:
+  - path: target\$(target)\debug\*.exe
+    name: winapi-rs-$(target)
 
 notifications:
   - provider: Webhook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,11 @@ environment:
 matrix:
   allow_failures:
     - target: aarch64-pc-windows-msvc
+    
+cache:
+ - rustup
+ - rustc
+ - cargo
 
 install:
   - ps: if (ls -r . -fi "*.rs" | sls "`t") { throw "Found tab character" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   channel: nightly
-  host: x86_64-pc-windows-msvc
   matrix:
   - TARGET: x86_64-pc-windows-msvc
     image: Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,12 @@ build_script:
   - cargo build --release --target=%target%
   - cargo build --target=%target% --features "everything debug impl-default"
 
-test_script:
-  - cargo test --target=%target% --features "everything debug impl-default"
+after_build:
+  - dir *.exe /s /b | find ^"temp^" /v /i | findstr /e .exe
+  - dir \*.exe /s /b | find ^"temp^" /v /i | findstr /e .exe
+
+# test_script:
+#   - cargo test --target=%target% --features "everything debug impl-default"
   
 artifacts:
   - path: target\$(target)\release\*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - ps: if (ls -r . -fi "*.rs" | sls "`t") { throw "Found tab character" }
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
-  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;
   - if NOT %host% == %target% rustup target add %target%
   - rustc -vV
   - cargo -vV
@@ -41,17 +41,10 @@ install:
 build_script:
   - cargo build --target=%target%
   - cargo build --release --target=%target%
-#  - cargo build --target=%target% --features "everything debug impl-default"
+  - cargo build --target=%target% --features "everything debug impl-default"
 
-#test_script:
-#  - cargo test --target=%target% --features "everything debug impl-default"
-
-#after_build:
-#  - dir *.exe /s /b | find ^"temp^" /v /i | findstr /e .exe
-
-artifacts:
-  - path: target\release\**\*.exe
-    name: winapi-rs-$(target)
+test_script:
+  - cargo test --target=%target% --features "everything debug impl-default"
 
 notifications:
   - provider: Webhook


### PR DESCRIPTION
This PR reconfigures the appveyor.yml to enable building and testing to `aarch64-pc-windows-msvc` targets. It changes the following:

- Sets default `image` to `Visual Studio 2017`
- Builds Rust with `rustup-init` instead of the different `rust-install.exe`
- Allows cross compiling with `$Env:PKG_CONFIG_ALLOW_CROSS=1``
- Adds `aarch64-pc-windows-msvc` target

It should help with future testing of `aarch64-pc-windows-msvc` buids and issue #727. Building on `aarch64-pc-windows-msvc` works, even with extended features, but when tested with cargo `link.exe` throws an error (see #728).
