### PR TITLE
Feature/variant false and safe array

### DIFF
--- a/src/shared/wtypes.rs
+++ b/src/shared/wtypes.rs
@@ -95,6 +95,7 @@ pub type BSTR = *mut OLECHAR;
 pub type LPBSTR = *mut BSTR;
 pub type VARIANT_BOOL = c_short;
 pub const VARIANT_TRUE: VARIANT_BOOL = -1;
+pub const VARIANT_FALSE: VARIANT_BOOL = 0;
 UNION!{union __MIDL_IWinTypes_0001 {
     [usize; 1],
     dwValue dwValue_mut: DWORD,

--- a/src/um/oleauto.rs
+++ b/src/um/oleauto.rs
@@ -73,6 +73,19 @@ extern "system" {
         lLbound: LONG,
         cElements: ULONG,
     ) -> *mut SAFEARRAY;
+    pub fn SafeArrayGetLBound(
+        psa: *mut SAFEARRAY,
+        nDim: UINT,
+        plLbound: *mut LONG
+    ) -> HRESULT;
+    pub fn SafeArrayGetUBound(
+        psa: *mut SAFEARRAY,
+        nDim: UINT,
+        plUbound: *mut LONG
+    ) -> HRESULT;
+    pub fn SafeArrayDestroy(
+        psa: *mut SAFEARRAY
+    ) -> HRESULT;
     pub fn VariantInit(
         pvarg: *mut VARIANTARG,
     );


### PR DESCRIPTION
Hi!

I added a few missing declarations (which I needed for my crate).

From `wtypes.h` (line 761):
```
#define VARIANT_TRUE ((VARIANT_BOOL)-1)
#define VARIANT_FALSE ((VARIANT_BOOL)0)
```

and `OleAuto.h` (line 139):
```
WINOLEAUTAPI SafeArrayDestroy(_In_ SAFEARRAY * psa);
...
WINOLEAUTAPI SafeArrayGetUBound(_In_ SAFEARRAY * psa, _In_ UINT nDim, _Out_ LONG * plUbound);
WINOLEAUTAPI SafeArrayGetLBound(_In_ SAFEARRAY * psa, _In_ UINT nDim, _Out_ LONG * plLbound);
```

Taken from Windows 10 SDK 10.0.17134.0.

P.S.
Amazing crate! Thank you :smile: :raised_hands: