### PR TITLE
Add doc-comment to test README examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ winapi-i686-pc-windows-gnu = { version = "0.3", path = "i686" }
 [target.x86_64-pc-windows-gnu.dependencies]
 winapi-x86_64-pc-windows-gnu = { version = "0.3", path = "x86_64" }
 
+[dev-dependencies]
+doc-comment = "0.3"
+
 [features]
 everything = []
 std = []

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Cargo.toml:
 winapi = { version = "0.3", features = ["winuser"] }
 ```
 main.rs:
-```rust
+```rust,no_run
 #[cfg(windows)] extern crate winapi;
 use std::io::Error;
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Cargo.toml:
 winapi = { version = "0.3", features = ["winuser"] }
 ```
 main.rs:
-```Rust
+```rust
 #[cfg(windows)] extern crate winapi;
 use std::io::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,13 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
+
 /// Hack for exported macros
 #[doc(hidden)]
 pub extern crate core as _core;


### PR DESCRIPTION
Since rustdoc nightly now provides "cfg(test)" when running on test mode, we can now use this macro on test mode only to check if README.md examples are working as expected.