### PR TITLE
Add um::winioctl::DISK_PERFORMANCE struct

### DIFF
--- a/src/um/winioctl.rs
+++ b/src/um/winioctl.rs
@@ -1074,3 +1074,18 @@ pub const IOCTL_VOLUME_IS_CLUSTERED: DWORD = CTL_CODE!(IOCTL_VOLUME_BASE, 12, ME
     FILE_ANY_ACCESS);
 pub const IOCTL_VOLUME_GET_GPT_ATTRIBUTES: DWORD = CTL_CODE!(IOCTL_VOLUME_BASE, 14,
     METHOD_BUFFERED, FILE_ANY_ACCESS);
+STRUCT!{struct DISK_PERFORMANCE {
+    BytesRead: LARGE_INTEGER,
+    BytesWritten: LARGE_INTEGER,
+    ReadTime: LARGE_INTEGER,
+    WriteTime: LARGE_INTEGER,
+    IdleTime: LARGE_INTEGER,
+    ReadCount: DWORD,
+    WriteCount: DWORD,
+    QueueDepth: DWORD,
+    SplitCount: DWORD,
+    QueryTime: LARGE_INTEGER,
+    StorageDeviceNumber: DWORD,
+    StorageManagerName: [WCHAR; 8],
+}}
+pub type PDISK_PERFORMANCE = *mut DISK_PERFORMANCE;

--- a/tests/structs_x86.rs
+++ b/tests/structs_x86.rs
@@ -7079,6 +7079,8 @@ fn um_winioctl() {
     assert_eq!(align_of::<DISK_EXTENT>(), 8);
     assert_eq!(size_of::<VOLUME_DISK_EXTENTS>(), 32);
     assert_eq!(align_of::<VOLUME_DISK_EXTENTS>(), 8);
+    assert_eq!(size_of::<DISK_PERFORMANCE>(), 88);
+    assert_eq!(align_of::<DISK_PERFORMANCE>(), 8);
 }
 #[cfg(feature = "winnetwk")] #[test]
 fn um_winnetwk() {

--- a/tests/structs_x86_64.rs
+++ b/tests/structs_x86_64.rs
@@ -7104,6 +7104,8 @@ fn um_winioctl() {
     assert_eq!(align_of::<DISK_EXTENT>(), 8);
     assert_eq!(size_of::<VOLUME_DISK_EXTENTS>(), 32);
     assert_eq!(align_of::<VOLUME_DISK_EXTENTS>(), 8);
+    assert_eq!(size_of::<DISK_PERFORMANCE>(), 88);
+    assert_eq!(align_of::<DISK_PERFORMANCE>(), 8);
 }
 #[cfg(feature = "winnetwk")] #[test]
 fn um_winnetwk() {


### PR DESCRIPTION
As described [here](https://docs.microsoft.com/en-US/windows/desktop/api/WinIoCtl/ns-winioctl-_disk_performance), based on the Win 10 SDK sources.