### PR TITLE
Trying to add `NtDeviceIoControlFile`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -201,7 +201,7 @@ const DATA: &'static [(&'static str, &'static [&'static str], &'static [&'static
     ("http", &["guiddef", "minwinbase", "minwindef", "sspi", "winnt", "ws2def"], &["winhttp"]),
     ("imm", &["minwindef", "windef"], &["imm32"]),
     ("interlockedapi", &["minwindef", "winnt"], &["kernel32"]),
-    ("ioapiset", &["basetsd", "minwinbase", "minwindef", "winnt"], &["kernel32"]),
+    ("ioapiset", &["basedef", "basetsd", "minwinbase", "minwindef", "ntdef", "winnt"], &["kernel32"]),
     ("jobapi", &["minwindef", "winnt"], &["kernel32"]),
     ("jobapi2", &["basetsd", "minwinbase", "minwindef", "ntdef", "winnt"], &["kernel32"]),
     ("knownfolders", &[], &[]),

--- a/src/um/ioapiset.rs
+++ b/src/um/ioapiset.rs
@@ -3,8 +3,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
+use km::basedef::{PIO_APC_ROUTINE, PIO_STATUS_BLOCK, PVOID};
 use shared::basetsd::{PULONG_PTR, ULONG_PTR};
 use shared::minwindef::{BOOL, DWORD, LPDWORD, LPVOID, PULONG, ULONG};
+use shared::ntdef::NTSTATUS;
 use um::minwinbase::{LPOVERLAPPED, LPOVERLAPPED_ENTRY};
 use um::winnt::HANDLE;
 extern "system" {
@@ -68,4 +70,18 @@ extern "system" {
     pub fn CancelSynchronousIo(
         hThread: HANDLE,
     ) -> BOOL;
+}
+extern "system" {
+    pub fn NtDeviceIoControlFile(
+        FileHandle: Handle,
+        Event: Handle,
+        ApcRoutine: PIO_APC_ROUTINE,
+        ApcContext: PVOID,
+        IoStatusBlock: ULONG,
+        IoControlCode: PVOID,
+        InputBuffer: PVOID,
+        InputBufferLength: ULONG,
+        OutputBuffer: PVOID,
+        OutputBufferLength: ULONG,
+    ) -> NTSTATUS;
 }


### PR DESCRIPTION
I know this is a deprecated function, but truly useful to communicate with AFD driver: https://docs.microsoft.com/en-us/windows/desktop/api/winternl/nf-winternl-ntdeviceiocontrolfile

Review is needed since I'm not so confident about the correctness. I'm fully prepared to multiple commits. : )