### PR TITLE
Changed handleapi feature link library from kernel32 to WindowsApp to…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -195,7 +195,7 @@ const DATA: &'static [(&'static str, &'static [&'static str], &'static [&'static
     ("fileapi", &["minwinbase", "minwindef", "winnt"], &["kernel32"]),
     ("functiondiscoverykeys_devpkey", &["wtypes"], &[]),
     ("gl-gl", &[], &["opengl32"]),
-    ("handleapi", &["minwindef", "winnt"], &["kernel32"]),
+    ("handleapi", &["minwindef", "winnt"], &["WindowsApp"]),
     ("heapapi", &["basetsd", "minwinbase", "minwindef", "winnt"], &["kernel32"]),
     ("highlevelmonitorconfigurationapi", &["minwindef", "physicalmonitorenumerationapi", "winnt"], &["dxva2"]),
     ("http", &["guiddef", "minwinbase", "minwindef", "sspi", "winnt", "ws2def"], &["winhttp"]),


### PR DESCRIPTION
While doing builds of ipc-channel and using windows 10 api CompareObjectHandles() I received an unresolved message for CompareObjectHandles().

Reading Microsoft link: https://docs.microsoft.com/en-us/uwp/win32-and-com/win32-apis I changed build.rs, handleapi link time library from kernel32 to WindowsApp.

After testing locally on my ipc-channel build and using my patched winapi v0.3.0 I removed the link time unresolved error and all ipc-channel tests passed.

… address/fix https://github.com/retep998/winapi-rs/issues/781.