### PR TITLE
Add `um::objidl::IPersistFile` and `um::shobjidl_core::IShellLink`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -313,7 +313,7 @@ const DATA: &'static [(&'static str, &'static [&'static str], &'static [&'static
     ("shellscalingapi", &["minwindef", "windef", "winnt"], &["shcore"]),
     ("shlobj", &["guiddef", "minwinbase", "minwindef", "shtypes", "windef", "winnt"], &["shell32"]),
     ("shobjidl", &["guiddef", "minwindef", "propsys", "shobjidl_core", "shtypes", "unknwnbase", "windef", "winnt"], &[]),
-    ("shobjidl_core", &["commctrl", "guiddef", "minwindef", "objidl", "propkeydef", "propsys", "unknwnbase", "windef", "winnt"], &[]),
+    ("shobjidl_core", &["commctrl", "guiddef", "minwinbase", "minwindef", "objidl", "propkeydef", "propsys", "shtypes", "unknwnbase", "windef", "winnt"], &[]),
     ("shtypes", &["guiddef", "minwindef", "winnt"], &[]),
     ("softpub", &[], &[]),
     ("spapidef", &["minwindef", "winnt"], &[]),

--- a/src/um/objidl.rs
+++ b/src/um/objidl.rs
@@ -11,7 +11,7 @@ use shared::minwindef::{BOOL, BYTE, DWORD, FILETIME, HGLOBAL, ULONG, WORD};
 use shared::ntdef::LONG;
 use shared::windef::{HBITMAP, HENHMETAFILE};
 use shared::wtypes::{CLIPFORMAT, HMETAFILEPICT};
-use shared::wtypesbase::{LPOLESTR, OLECHAR};
+use shared::wtypesbase::{LPCOLESTR, LPOLESTR, OLECHAR};
 use um::objidlbase::{IEnumString, IStream, STATSTG};
 use um::unknwnbase::{IUnknown, IUnknownVtbl};
 use um::winnt::{HRESULT, ULARGE_INTEGER};
@@ -314,6 +314,24 @@ interface IStorage(IStorageVtbl): IUnknown(IUnknownVtbl) {
     fn Stat(
         pstatstg: *mut STATSTG,
         grfStatFlag: DWORD,
+    ) -> HRESULT,
+}}
+RIDL!{#[uuid(0x0000010b, 0x0000, 0x0000, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46)]
+interface IPersistFile(IPersistFileVtbl): IPersist(IPersistVtbl) {
+    fn IsDirty() -> HRESULT,
+    fn Load(
+        pszFileName: LPCOLESTR,
+        dwMode: DWORD,
+    ) -> HRESULT,
+    fn Save(
+        pszFileName: LPCOLESTR,
+        fRemember: BOOL,
+    ) -> HRESULT,
+    fn SaveCompleted(
+        pszFileName: LPCOLESTR,
+    ) -> HRESULT,
+    fn GetCurFile(
+        ppszFileName: *mut LPOLESTR,
     ) -> HRESULT,
 }}
 STRUCT!{struct DVTARGETDEVICE {

--- a/src/um/shobjidl_core.rs
+++ b/src/um/shobjidl_core.rs
@@ -8,11 +8,13 @@ use shared::guiddef::{REFGUID, REFIID};
 use shared::minwindef::{BOOL, DWORD, UINT, ULONG, WORD};
 use shared::windef::{COLORREF, HICON, HWND, RECT};
 use um::commctrl::HIMAGELIST;
+use um::minwinbase::{WIN32_FIND_DATAA, WIN32_FIND_DATAW};
 use um::objidl::IBindCtx;
 use um::propkeydef::REFPROPERTYKEY;
 use um::propsys::GETPROPERTYSTOREFLAGS;
+use um::shtypes::{PCIDLIST_ABSOLUTE, PIDLIST_ABSOLUTE};
 use um::unknwnbase::{IUnknown, IUnknownVtbl};
-use um::winnt::{HRESULT, LPCWSTR, LPWSTR, ULONGLONG, WCHAR};
+use um::winnt::{HRESULT, LPCSTR, LPCWSTR, LPSTR, LPWSTR, ULONGLONG, WCHAR};
 DEFINE_GUID!{CLSID_DesktopWallpaper,
     0xc2cf3110, 0x460e, 0x4fc1, 0xb9, 0xd0, 0x8a, 0x1c, 0x0c, 0x9c, 0xc4, 0xbd}
 DEFINE_GUID!{CLSID_TaskbarList,
@@ -342,6 +344,142 @@ interface IDesktopWallpaper(IDesktopWallpaperVtbl): IUnknown(IUnknownVtbl) {
     ) -> HRESULT,
     fn Enable(
         enable: BOOL,
+    ) -> HRESULT,
+}}
+RIDL!{#[uuid(0x000214ee, 0x0000, 0x0000, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46)]
+interface IShellLinkA(IShellLinkAVtbl): IUnknown(IUnknownVtbl) {
+    fn GetPath(
+        pszFile: LPSTR,
+        cch: c_int,
+        pfd: *mut WIN32_FIND_DATAA,
+        fFlags: DWORD,
+    ) -> HRESULT,
+    fn GetIDList(
+        ppidl: *mut PIDLIST_ABSOLUTE,
+    ) -> HRESULT,
+    fn SetIDList(
+        pidl: PCIDLIST_ABSOLUTE,
+    ) -> HRESULT,
+    fn GetDescription(
+        pszName: LPSTR,
+        cch: c_int,
+    ) -> HRESULT,
+    fn SetDescription(
+        pszName: LPCSTR,
+    ) -> HRESULT,
+    fn GetWorkingDirectory(
+        pszDir: LPSTR,
+        cch: c_int,
+    ) -> HRESULT,
+    fn SetWorkingDirectory(
+        pszDir: LPCSTR,
+    ) -> HRESULT,
+    fn GetArguments(
+        pszArgs: LPSTR,
+        cch: c_int,
+    ) -> HRESULT,
+    fn SetArguments(
+        pszArgs: LPCSTR,
+    ) -> HRESULT,
+    fn GetHotkey(
+        pwHotkey: *mut WORD,
+    ) -> HRESULT,
+    fn SetHotkey(
+        wHotkey: WORD,
+    ) -> HRESULT,
+    fn GetShowCmd(
+        piShowCmd: *mut c_int,
+    ) -> HRESULT,
+    fn SetShowCmd(
+        iShowCmd: c_int,
+    ) -> HRESULT,
+    fn GetIconLocation(
+        pszIconPath: LPSTR,
+        cch: c_int,
+        piIcon: *mut c_int,
+    ) -> HRESULT,
+    fn SetIconLocation(
+        pszIconPath: LPCSTR,
+        iIcon: c_int,
+    ) -> HRESULT,
+    fn SetRelativePath(
+        pszPathRel: LPCSTR,
+        dwReserved: DWORD,
+    ) -> HRESULT,
+    fn Resolve(
+        hwnd: HWND,
+        fFlags: DWORD,
+    ) -> HRESULT,
+    fn SetPath(
+        pszFile: LPCSTR,
+    ) -> HRESULT,
+}}
+RIDL!{#[uuid(0x000214f9, 0x0000, 0x0000, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46)]
+interface IShellLinkW(IShellLinkWVtbl): IUnknown(IUnknownVtbl) {
+    fn GetPath(
+        pszFile: LPWSTR,
+        cch: c_int,
+        pfd: *mut WIN32_FIND_DATAW,
+        fFlags: DWORD,
+    ) -> HRESULT,
+    fn GetIDList(
+        ppidl: *mut PIDLIST_ABSOLUTE,
+    ) -> HRESULT,
+    fn SetIDList(
+        pidl: PCIDLIST_ABSOLUTE,
+    ) -> HRESULT,
+    fn GetDescription(
+        pszName: LPWSTR,
+        cch: c_int,
+    ) -> HRESULT,
+    fn SetDescription(
+        pszName: LPCWSTR,
+    ) -> HRESULT,
+    fn GetWorkingDirectory(
+        pszDir: LPWSTR,
+        cch: c_int,
+    ) -> HRESULT,
+    fn SetWorkingDirectory(
+        pszDir: LPCWSTR,
+    ) -> HRESULT,
+    fn GetArguments(
+        pszArgs: LPWSTR,
+        cch: c_int,
+    ) -> HRESULT,
+    fn SetArguments(
+        pszArgs: LPCWSTR,
+    ) -> HRESULT,
+    fn GetHotkey(
+        pwHotkey: *mut WORD,
+    ) -> HRESULT,
+    fn SetHotkey(
+        wHotkey: WORD,
+    ) -> HRESULT,
+    fn GetShowCmd(
+        piShowCmd: *mut c_int,
+    ) -> HRESULT,
+    fn SetShowCmd(
+        iShowCmd: c_int,
+    ) -> HRESULT,
+    fn GetIconLocation(
+        pszIconPath: LPWSTR,
+        cch: c_int,
+        piIcon: *mut c_int,
+    ) -> HRESULT,
+    fn SetIconLocation(
+        pszIconPath: LPCWSTR,
+        iIcon: c_int,
+    ) -> HRESULT,
+    fn SetRelativePath(
+        pszPathRel: LPCWSTR,
+        dwReserved: DWORD,
+    ) -> HRESULT,
+    fn Resolve(
+        hwnd: HWND,
+        fFlags: DWORD,
+    ) -> HRESULT,
+    fn SetPath(
+        pszFile: LPCWSTR,
     ) -> HRESULT,
 }}
 RIDL!{#[uuid(0xc2cf3110, 0x460e, 0x4fc1, 0xb9, 0xd0, 0x8a, 0x1c, 0x0c, 0x9c, 0xc4, 0xbd)]


### PR DESCRIPTION
This adds the `IPersistFile` and `IShellLink` COM interfaces. I'm not exactly an expert in COM but I can confirm that this works for creating [shell links].

[shell links]: https://docs.microsoft.com/en-us/windows/win32/shell/links
