### PR TITLE
Add IsWow64Process2

### DIFF
--- a/src/um/wow64apiset.rs
+++ b/src/um/wow64apiset.rs
@@ -16,11 +16,6 @@ extern "system" {
         hProcess: HANDLE,
         Wow64Process: PBOOL,
     ) -> BOOL;
-    pub fn IsWow64Process2(
-        hProcess: HANDLE,
-        pProcessMachine: PUSHORT,
-        pNativeMachine: PUSHORT,
-    ) -> BOOL;
     pub fn GetSystemWow64DirectoryA(
         lpBuffer: LPSTR,
         uSize: UINT,
@@ -29,4 +24,9 @@ extern "system" {
         lpBuffer: LPWSTR,
         uSize: UINT,
     ) -> UINT;
+    pub fn IsWow64Process2(
+        hProcess: HANDLE,
+        pProcessMachine: PUSHORT,
+        pNativeMachine: PUSHORT,
+    ) -> BOOL;
 }

--- a/src/um/wow64apiset.rs
+++ b/src/um/wow64apiset.rs
@@ -3,7 +3,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
-use shared::minwindef::{BOOL, PBOOL, UINT};
+use shared::minwindef::{BOOL, PBOOL, PUSHORT, UINT};
 use um::winnt::{HANDLE, LPSTR, LPWSTR, PVOID};
 extern "system" {
     pub fn Wow64DisableWow64FsRedirection(
@@ -15,6 +15,11 @@ extern "system" {
     pub fn IsWow64Process(
         hProcess: HANDLE,
         Wow64Process: PBOOL,
+    ) -> BOOL;
+    pub fn IsWow64Process2(
+        hProcess: HANDLE,
+        pProcessMachine: PUSHORT,
+        pNativeMachine: PUSHORT,
     ) -> BOOL;
     pub fn GetSystemWow64DirectoryA(
         lpBuffer: LPSTR,


### PR DESCRIPTION
IsWow64Process use is discouraged, favoring IsWow64Process2 which was missing in winapi-rs.