### PR TITLE
Fix deprecated warnings in test

### DIFF
--- a/tests/code_checkers/build_headers_sort.rs
+++ b/tests/code_checkers/build_headers_sort.rs
@@ -51,11 +51,11 @@ fn check_build_headers_sorted() {
     let mut new_group = false;
 
     for (pos, line) in content.lines().enumerate() {
-        let line = line.trim_left();
+        let line = line.trim_start();
         if !inside && line.starts_with("const DATA: ") {
             inside = true;
         } else if inside == true {
-            let line = line.trim_left();
+            let line = line.trim_start();
             if line.starts_with("//") {
                 new_group = true;
                 continue;

--- a/tests/code_checkers/check_features.rs
+++ b/tests/code_checkers/check_features.rs
@@ -15,11 +15,11 @@ fn get_libs() -> Vec<String> {
     let mut inside = false;
     let mut files_deps = Vec::new();
     for line in content.lines() {
-        let line = line.trim_left();
+        let line = line.trim_start();
         if !inside && line.starts_with("const DATA: ") {
             inside = true;
         } else if inside == true {
-            let line = line.trim_left();
+            let line = line.trim_start();
             if line.starts_with("//") {
                 continue
             } else if !line.starts_with("(\"") {

--- a/tests/code_checkers/check_lines.rs
+++ b/tests/code_checkers/check_lines.rs
@@ -60,7 +60,7 @@ fn check_module<P: AsRef<Path>>(path: P, err_list: &mut String) {
             }
             let len = line.split_terminator("//")
                           .next()
-                          .map(|actual| actual.trim_right().chars().count())
+                          .map(|actual| actual.trim_end().chars().count())
                           .unwrap_or(0);
             if line.is_empty() || len > MAX_LEN {
                 if !marked {

--- a/tests/code_checkers/headers.rs
+++ b/tests/code_checkers/headers.rs
@@ -118,11 +118,11 @@ fn check_imports() {
     let mut inside = false;
     let mut files_deps: HashMap<String, Vec<String>> = HashMap::new();
     for line in content.lines() {
-        let line = line.trim_left();
+        let line = line.trim_start();
         if !inside && line.starts_with("const DATA: ") {
             inside = true;
         } else if inside == true {
-            let line = line.trim_left();
+            let line = line.trim_start();
             if line.starts_with("//") {
                 continue;
             } else if !line.starts_with("(\"") {


### PR DESCRIPTION
This PR fixes the deprecated warnings about the using of `trim_left` and `trim_right` in the test code.