### PR TITLE
add rustc-dep-of-std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ default-target = "x86_64-pc-windows-msvc"
 travis-ci = { repository = "retep998/winapi-rs", branch = "0.3" }
 appveyor = { repository = "retep998/winapi-rs", branch = "0.3", service = "github" }
 
+[dependencies]
+# When built as part of libstd
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+compiler_builtins = { version = "0.1.2", optional = true }
+
 [target.i686-pc-windows-gnu.dependencies]
 winapi-i686-pc-windows-gnu = { version = "0.4", path = "i686" }
 [target.x86_64-pc-windows-gnu.dependencies]
@@ -31,6 +36,7 @@ everything = []
 impl-debug = []
 impl-default = []
 std = []
+rustc-dep-of-std = ["core", "compiler_builtins", "winapi-i686-pc-windows-gnu/rustc-dep-of-std", "winapi-x86_64-pc-windows-gnu/rustc-dep-of-std"]
 #km
 d3dkmthk = []
 #mmos

--- a/i686/Cargo.toml
+++ b/i686/Cargo.toml
@@ -8,3 +8,11 @@ repository = "https://github.com/retep998/winapi-rs"
 keywords = ["windows"]
 include = ["/src/*", "/lib/*", "/Cargo.toml", "/LICENSE-MIT", "/LICENSE-APACHE", "/build.rs"]
 build = "build.rs"
+
+[dependencies]
+# When built as part of libstd
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+compiler_builtins = { version = "0.1.2", optional = true }
+
+[features]
+rustc-dep-of-std = ["core", "compiler_builtins"]

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -8,3 +8,11 @@ repository = "https://github.com/retep998/winapi-rs"
 keywords = ["windows"]
 include = ["/src/*", "/lib/*", "/Cargo.toml", "/LICENSE-MIT", "/LICENSE-APACHE", "/build.rs"]
 build = "build.rs"
+
+[dependencies]
+# When built as part of libstd
+core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+compiler_builtins = { version = "0.1.2", optional = true }
+
+[features]
+rustc-dep-of-std = ["core", "compiler_builtins"]


### PR DESCRIPTION
This commit paves the way for libstd to depend on winapi and crates that
depend on winapi.

Tested with a local build of libstd on both `-msvc` and `-gnu` targets.

While it's possible to move small parts of libstd to winapi with this commit, it will be tricky to do a large-scale refactor until #771 and #323 are addressed.