### PR TITLE
Fix NetUserGetLocalGroups definition

### DIFF
--- a/src/um/lmaccess.rs
+++ b/src/um/lmaccess.rs
@@ -62,6 +62,7 @@ extern "system" {
     ) -> NET_API_STATUS;
     pub fn NetUserGetLocalGroups(
         servername: LPCWSTR,
+        username: LPCWSTR,
         level: DWORD,
         flags: DWORD,
         bufptr: *mut LPBYTE,


### PR DESCRIPTION
As you can see [here](https://docs.microsoft.com/fr-fr/windows/win32/api/lmaccess/nf-lmaccess-netusergetlocalgroups), the function was missing an argument.