### PR TITLE
Mark dialog templates as repr(packed)

### DIFF
--- a/src/um/winuser.rs
+++ b/src/um/winuser.rs
@@ -2509,7 +2509,8 @@ pub const HWND_TOP: HWND = 0 as HWND;
 pub const HWND_BOTTOM: HWND = 1 as HWND;
 pub const HWND_TOPMOST: HWND = -1isize as HWND;
 pub const HWND_NOTOPMOST: HWND = -2isize as HWND;
-STRUCT!{struct DLGTEMPLATE {
+// FIXME packed(2)
+STRUCT!{#[repr(packed)] struct DLGTEMPLATE {
     style: DWORD,
     dwExtendedStyle: DWORD,
     cdit: WORD,
@@ -2522,7 +2523,8 @@ pub type LPDLGTEMPLATEA = *mut DLGTEMPLATE;
 pub type LPDLGTEMPLATEW = *mut DLGTEMPLATE;
 pub type LPCDLGTEMPLATEA = *const DLGTEMPLATE;
 pub type LPCDLGTEMPLATEW = *const DLGTEMPLATE;
-STRUCT!{struct DLGITEMTEMPLATE {
+// FIXME packed(2)
+STRUCT!{#[repr(packed)] struct DLGITEMTEMPLATE {
     style: DWORD,
     dwExtendedStyle: DWORD,
     x: c_short,


### PR DESCRIPTION
Both [`DLGTEMPLATE`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-dlgtemplate) and [`DLGITEMTEMPLATE`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-dlgitemtemplate) are defined with a `packed(2)` alignment [in `winuser.h`](https://github.com/wine-mirror/wine/blob/148fc1adb53aa1d78a67b2a0ee5ea8058d92589a/include/winuser.h#L2130-L2168) in order to cut off some padding bytes from the end. This PR adds a standard `packed` alignment attribute to remove the padding bytes without bumping the MSRV. Those should be changed to `packed(2)` once we move to a Rust version that supports `packed(N)`.