### PR TITLE
Make uuidof() return a static reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,10 +62,10 @@ pub mod ctypes {
 // This trait should be implemented for all COM interfaces
 pub trait Interface {
     // Returns the IID of the Interface
-    fn uuidof() -> shared::guiddef::GUID;
+    fn uuidof() -> &'static shared::guiddef::GUID;
 }
 // This trait should be implemented for all COM classes
 pub trait Class {
     // Returns the CLSID of the Class
-    fn uuidof() -> shared::guiddef::GUID;
+    fn uuidof() -> &'static shared::guiddef::GUID;
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -150,8 +150,8 @@ macro_rules! RIDL {
         pub enum $class {}
         impl $crate::Class for $class {
             #[inline]
-            fn uuidof() -> $crate::shared::guiddef::GUID {
-                $crate::shared::guiddef::GUID {
+            fn uuidof() -> &'static $crate::shared::guiddef::GUID {
+                &$crate::shared::guiddef::GUID {
                     Data1: $l,
                     Data2: $w1,
                     Data3: $w2,
@@ -265,8 +265,8 @@ macro_rules! RIDL {
     ) => (
         impl $crate::Interface for $interface {
             #[inline]
-            fn uuidof() -> $crate::shared::guiddef::GUID {
-                $crate::shared::guiddef::GUID {
+            fn uuidof() -> &'static $crate::shared::guiddef::GUID {
+                &$crate::shared::guiddef::GUID {
                     Data1: $l,
                     Data2: $w1,
                     Data3: $w2,


### PR DESCRIPTION
These methods currently return GUID by value which causes its unnecessary initialization in the stack instead of referring the value stored in a read-only section e.g. `.rdata`.

https://rust.godbolt.org/z/7bA-yK - a rough example of what's going on.

This is a breaking change but it shouldn't be something drastically hard to follow. The reference may always be dereferenced and then mutably referenced in rare cases where the actual value or a mutable reference is needed since GUID is `Copy`.



