### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: retep998


### PR DESCRIPTION
I recently released [`cargo-fund`](https://users.rust-lang.org/t/cargo-fund-discover-funding-links-for-your-projects-dependencies/43251?u=acfoltzer), and noticed that while there is sponsorship information in your README, it's not yet encoded in an easily machine-readable way. Adding this metadata will add a "Sponsor" button to the repo, and allow `cargo-fund` to show the project's sponsorship link. For more about this file format, see the [Github docs](https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository).