### PR TITLE
Explicitly specify targets to build on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ build = "build.rs"
 [package.metadata.docs.rs]
 features = ["everything", "impl-debug", "impl-default"]
 default-target = "x86_64-pc-windows-msvc"
+targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
 
 [badges]
 travis-ci = { repository = "retep998/winapi-rs", branch = "0.3" }


### PR DESCRIPTION
This makes sure that all Windows platforms will have documentation on
docs.rs even after docs.rs stops building all tier 1 targets by default.
See https://github.com/rust-lang/docs.rs/pull/532 and
https://github.com/rust-lang/docs.rs/issues/343 for more context. There will be an blog post to blog.rust-lang.org/ shortly with more details (but the change is a ways in the future).

Additionally, this stops building targets on Mac and Linux since those
targets are just empty anyway.