### PR TITLE
Added GetGuiResources declaration.

### DIFF
--- a/src/um/winuser.rs
+++ b/src/um/winuser.rs
@@ -6067,6 +6067,17 @@ extern "system" {
         dwData: ULONG_PTR,
     ) -> BOOL;
 }
+pub const GR_GDIOBJECTS: DWORD = 0;
+pub const GR_USEROBJECTS: DWORD = 1;
+pub const GR_GDIOBJECTS_PEAK: DWORD = 2;
+pub const GR_USEROBJECTS_PEAK: DWORD = 4;
+pub const GR_GLOBAL: HANDLE = -2isize as HANDLE;
+extern "system" {
+    pub fn GetGuiResources(
+        hProcess: HANDLE,
+        uiFlags: DWORD,
+    ) -> DWORD;
+}
 //12083
 pub const SPI_GETBEEP: UINT = 0x0001;
 pub const SPI_SETBEEP: UINT = 0x0002;


### PR DESCRIPTION
Resolves #888.

This is a non-breaking change. All identifiers and associated values have been copy-pasted from the *winuser.h* SDK header file.