### PR TITLE
add definitions for afunix.h

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ std = []
 d3dkmthk = []
 #mmos
 #shared
+afunix = []
 basetsd = []
 bcrypt = []
 bthdef = []

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ const DATA: &'static [(&'static str, &'static [&'static str], &'static [&'static
     ("d3dkmthk", &["basetsd", "d3dukmdt", "minwindef", "ntdef", "windef"], &[]),
     // mmos
     // shared
+    ("afunix", &["minwindef", "winnt", "ws2def"], &[]),
     ("basetsd", &[], &[]),
     ("bcrypt", &["minwindef", "winnt"], &["bcrypt"]),
     ("bthdef", &["bthsdpdef", "guiddef", "minwindef", "ntdef"], &[]),

--- a/src/shared/afunix.rs
+++ b/src/shared/afunix.rs
@@ -1,0 +1,10 @@
+use shared::minwindef::DWORD;
+use shared::ws2def::{ADDRESS_FAMILY, IOC_VENDOR};
+use um::winnt::CHAR;
+pub const UNIX_PATH_MAX: usize = 108;
+STRUCT!{struct SOCKADDR_UN {
+    sun_family: ADDRESS_FAMILY,
+    sun_path: [CHAR; UNIX_PATH_MAX],
+}}
+pub type PSOCKETADDR_UN = *mut SOCKADDR_UN;
+pub const SIO_AF_UNIX_GETPEERPID: DWORD = _WSAIOR!(IOC_VENDOR, 256);

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -4,6 +4,7 @@
 // All files in the project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
 //! Headers shared between user mode and kernel mode
+#[cfg(feature = "afunix")] pub mod afunix;
 #[cfg(feature = "basetsd")] pub mod basetsd;
 #[cfg(feature = "bcrypt")] pub mod bcrypt;
 #[cfg(feature = "bthdef")] pub mod bthdef;

--- a/tests/structs_x86.rs
+++ b/tests/structs_x86.rs
@@ -1,6 +1,12 @@
 #![cfg(all(windows, target_arch = "x86"))]
 extern crate winapi;
 use std::mem::{size_of, align_of};
+#[cfg(feature = "afunix")] #[test]
+fn shared_afunix() {
+    use winapi::shared::afunix::*;
+    assert_eq!(size_of::<SOCKADDR_UN>(), 110);
+    assert_eq!(align_of::<SOCKADDR_UN>(), 2);
+}
 #[cfg(feature = "bcrypt")] #[test]
 fn shared_bcrypt() {
     use winapi::shared::bcrypt::*;

--- a/tests/structs_x86_64.rs
+++ b/tests/structs_x86_64.rs
@@ -1,6 +1,12 @@
 #![cfg(all(windows, target_arch = "x86_64"))]
 extern crate winapi;
 use std::mem::{size_of, align_of};
+#[cfg(feature = "afunix")] #[test]
+fn shared_afunix() {
+    use winapi::shared::afunix::*;
+    assert_eq!(size_of::<SOCKADDR_UN>(), 110);
+    assert_eq!(align_of::<SOCKADDR_UN>(), 2);
+}
 #[cfg(feature = "bcrypt")] #[test]
 fn shared_bcrypt() {
     use winapi::shared::bcrypt::*;


### PR DESCRIPTION
Since Windows 17063, there is UNIX domain socket support in Windows. Along with the support `afunix.h` is added to define `SOCKADDR_UN` struct for creating UNIX domain sockets.

This pull request adds the definition mirrors `afunix.h` in Windows SDK.

See "[AF_UNIX comes to Windows](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/)"

Windows header file location: `C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared\afunix.h`