### PR TITLE
Allow for external system libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ winapi-i686-pc-windows-gnu = { version = "0.4", path = "i686" }
 winapi-x86_64-pc-windows-gnu = { version = "0.4", path = "x86_64" }
 
 [features]
+external_lib = []
 debug = ["impl-debug"]
 everything = []
 impl-debug = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ winapi-i686-pc-windows-gnu = { version = "0.4", path = "i686" }
 winapi-x86_64-pc-windows-gnu = { version = "0.4", path = "x86_64" }
 
 [features]
-external-lib = []
 debug = ["impl-debug"]
 everything = []
+external-lib = []
 impl-debug = []
 impl-default = []
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ winapi-i686-pc-windows-gnu = { version = "0.4", path = "i686" }
 winapi-x86_64-pc-windows-gnu = { version = "0.4", path = "x86_64" }
 
 [features]
-external_lib = []
+external-lib = []
 debug = ["impl-debug"]
 everything = []
 impl-debug = []

--- a/build.rs
+++ b/build.rs
@@ -515,7 +515,7 @@ fn try_everything() {
     graph.check_everything();
     graph.resolve_dependencies();
     graph.emit_features();
-    //graph.emit_libraries();
+    graph.emit_libraries();
 }
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/build.rs
+++ b/build.rs
@@ -515,7 +515,7 @@ fn try_everything() {
     graph.check_everything();
     graph.resolve_dependencies();
     graph.emit_features();
-    graph.emit_libraries();
+    //graph.emit_libraries();
 }
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/build.rs
+++ b/build.rs
@@ -469,25 +469,27 @@ impl Graph {
         }
     }
     fn emit_libraries(&self) {
-        let mut libs = self.0.iter().filter(|&(_, header)| {
-            header.included.get()
-        }).flat_map(|(_, header)| {
-            header.libraries.iter()
-        }).collect::<Vec<_>>();
-        libs.sort();
-        libs.dedup();
-        // FIXME Temporary hacks until build script is redesigned.
-        libs.retain(|&&lib| match &*var("TARGET").unwrap() {
-            "aarch64-pc-windows-msvc" | "aarch64-uwp-windows-msvc" | "thumbv7a-pc-windows-msvc" => {
-                if lib == "opengl32" { false }
-                else { true }
-            },
-            _ => true,
-        });
-        let prefix = library_prefix();
-        let kind = library_kind();
-        for lib in libs {
-            println!("cargo:rustc-link-lib={}={}{}", kind, prefix, lib);
+        if var("CARGO_FEATURE_EXTERNAL_LIB").is_err() {
+            let mut libs = self.0.iter().filter(|&(_, header)| {
+                header.included.get()
+            }).flat_map(|(_, header)| {
+                header.libraries.iter()
+            }).collect::<Vec<_>>();
+            libs.sort();
+            libs.dedup();
+            // FIXME Temporary hacks until build script is redesigned.
+            libs.retain(|&&lib| match &*var("TARGET").unwrap() {
+                "aarch64-pc-windows-msvc" | "aarch64-uwp-windows-msvc" | "thumbv7a-pc-windows-msvc" => {
+                    if lib == "opengl32" { false }
+                    else { true }
+                },
+                _ => true,
+            });
+            let prefix = library_prefix();
+            let kind = library_kind();
+            for lib in libs {
+                println!("cargo:rustc-link-lib={}={}{}", kind, prefix, lib);
+            }
         }
     }
 }

--- a/tests/code_checkers/check_features.rs
+++ b/tests/code_checkers/check_features.rs
@@ -111,7 +111,7 @@ fn check_missing_features_in_cargo_file(build_features: &[String],
                                         cargo_features: &[String],
                                         errors: &mut u32) {
     const FEATURES_TO_IGNORE: &'static [&'static str] = &[
-        "debug", "everything", "impl-debug", "impl-default", "std",
+        "debug", "everything", "external-lib", "impl-debug", "impl-default", "std",
     ];
     let mut it1 = 0;
     let mut it2 = 0;


### PR DESCRIPTION
Added a feature toggle which allow the user of winapi to disable the linking of standard system libs which allows the user to provide their own. Useful to support more windows like platforms.