### PR TITLE
COMpatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        toolchain: [nightly-x86_64-msvc, nightly-i686-msvc, nightly-x86_64-gnu, nightly-i686-gnu, 1.6.0-x86_64-msvc]
+        toolchain: [nightly-x86_64-msvc, nightly-i686-msvc, nightly-x86_64-gnu, nightly-i686-gnu, 1.25.0-x86_64-msvc]
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   - host: i686-pc-windows-gnu
     channel: nightly
   - host: x86_64-pc-windows-gnu
-    channel: 1.6.0
+    channel: 1.25.0
 
 install:
   - ps: if (ls -r . -fi "*.rs" | sls "`t") { throw "Found tab character" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,17 @@ pub mod ctypes {
     pub type wchar_t = u16;
 }
 // This trait should be implemented for all COM interfaces
-pub trait Interface {
+pub unsafe trait Interface : Sized + 'static {
+    /// A COM compatible V-Table
+    type VTable;
+    /// The interface that this interface inherits from
+    type Super: Interface;
+    /// The associated id for this interface
+    const IID: shared::guiddef::GUID;
     // Returns the IID of the Interface
-    fn uuidof() -> shared::guiddef::GUID;
+    fn uuidof() -> shared::guiddef::GUID {
+        <Self as Interface>::IID
+    }
 }
 // This trait should be implemented for all COM classes
 pub trait Class {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -214,13 +214,15 @@ macro_rules! RIDL {
     );
     (@method fn $method:ident($($p:ident : $t:ty,)*) -> $rtr:ty) => (
         #[inline] pub unsafe fn $method(&self, $($p: $t,)*) -> $rtr {
-            ((*self.lpVtbl).$method)(self as *const _ as *mut _, $($p,)*)
+            ((*self.lpVtbl).$method)($crate::_core::ptr::NonNull::new_unchecked(
+                self as *const _ as *mut _), $($p,)*)
         }
     );
     (@method #[fixme] fn $method:ident($($p:ident : $t:ty,)*) -> $rtr:ty) => (
         #[inline] pub unsafe fn $method(&self, $($p: $t,)*) -> $rtr {
             let mut ret = $crate::_core::mem::uninitialized();
-            ((*self.lpVtbl).$method)(self as *const _ as *mut _, &mut ret, $($p,)*);
+            ((*self.lpVtbl).$method)($crate::_core::ptr::NonNull::new_unchecked(
+                self as *const _ as *mut _), &mut ret, $($p,)*);
             ret
         }
     );
@@ -231,7 +233,7 @@ macro_rules! RIDL {
         pub struct $vtbl {
             $($fields)*
             $(pub $method: unsafe extern "system" fn(
-                This: *mut $interface,
+                This: $crate::_core::ptr::NonNull<$crate::_core::ptr::NonNull<$vtbl>>,
                 $($p: $t,)*
             ) -> $rtr,)*
         }}
@@ -242,7 +244,7 @@ macro_rules! RIDL {
         RIDL!{@vtbl $interface $vtbl (
             $($fields)*
             pub $method: unsafe extern "system" fn(
-                This: *mut $interface,
+                This: $crate::_core::ptr::NonNull<$crate::_core::ptr::NonNull<$vtbl>>,
                 $($p: $t,)*
             ) -> $rtr,
         ) $($tail)*}
@@ -253,7 +255,7 @@ macro_rules! RIDL {
         RIDL!{@vtbl $interface $vtbl (
             $($fields)*
             pub $method: unsafe extern "system" fn(
-                This: *mut $interface,
+                This: $crate::_core::ptr::NonNull<$crate::_core::ptr::NonNull<$vtbl>>,
                 ret: *mut $rtr,
                 $($p: $t,)*
             ) -> *mut $rtr,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -174,7 +174,7 @@ macro_rules! RIDL {
         impl $interface {
             $(RIDL!{@method $(#[$($attrs)*])* fn $method($($p: $t,)*) -> $rtr})+
         }
-        RIDL!{@uuid $interface $($uuid),+}
+        RIDL!{@interface_trait $interface $vtbl $interface $($uuid),+}
     );
     (#[uuid($($uuid:expr),+)]
     interface $interface:ident ($vtbl:ident) : $pinterface:ident ($pvtbl:ident) {}) => (
@@ -184,7 +184,7 @@ macro_rules! RIDL {
             pub lpVtbl: *const $vtbl,
         }
         RIDL!{@deref $interface $pinterface}
-        RIDL!{@uuid $interface $($uuid),+}
+        RIDL!{@interface_trait $interface $vtbl $pinterface $($uuid),+}
     );
     (#[uuid($($uuid:expr),+)]
     interface $interface:ident ($vtbl:ident) : $pinterface:ident ($pvtbl:ident) {$(
@@ -201,7 +201,7 @@ macro_rules! RIDL {
             $(RIDL!{@method $(#[$($attrs)*])* fn $method($($p: $t,)*) -> $rtr})+
         }
         RIDL!{@deref $interface $pinterface}
-        RIDL!{@uuid $interface $($uuid),+}
+        RIDL!{@interface_trait $interface $vtbl $pinterface $($uuid),+}
     );
     (@deref $interface:ident $pinterface:ident) => (
         impl $crate::_core::ops::Deref for $interface {
@@ -259,20 +259,19 @@ macro_rules! RIDL {
             ) -> *mut $rtr,
         ) $($tail)*}
     );
-    (@uuid $interface:ident
+    (@interface_trait $interface:ident $vtbl:ident $pinterface:ident
         $l:expr, $w1:expr, $w2:expr,
         $b1:expr, $b2:expr, $b3:expr, $b4:expr, $b5:expr, $b6:expr, $b7:expr, $b8:expr
     ) => (
-        impl $crate::Interface for $interface {
-            #[inline]
-            fn uuidof() -> $crate::shared::guiddef::GUID {
-                $crate::shared::guiddef::GUID {
-                    Data1: $l,
-                    Data2: $w1,
-                    Data3: $w2,
-                    Data4: [$b1, $b2, $b3, $b4, $b5, $b6, $b7, $b8],
-                }
-            }
+        unsafe impl $crate::Interface for $interface {
+            type VTable = $vtbl;
+            type Super = $pinterface;
+            const IID: $crate::shared::guiddef::GUID = $crate::shared::guiddef::GUID {
+                Data1: $l,
+                Data2: $w1,
+                Data3: $w2,
+                Data4: [$b1, $b2, $b3, $b4, $b5, $b6, $b7, $b8],
+            };
         }
     );
     (@item $thing:item) => ($thing);


### PR DESCRIPTION
This PR aims to provide the ability to use interfaces defined in this crate with Microsoft's [com crate](https://github.com/microsoft/com-rs).

This, along with [my PR in com-rs](https://github.com/microsoft/com-rs/pull/200) and [some glue code](https://github.com/hadeutscher/HaCam/blob/master/src/com_helper.rs) that ties everything together, allows us to do some cool stuff, such as produce COM classes that implement interfaces from the Windows API, e.g.


```rust
use winapi::um::strmif::IFilterMapper2;

// a2c3c6ea-a415-4809-a55c-b49934d81ab7
DEFINE_GUID!(CLSID_MY_CLASS, 0xa2c3c6ea, 0xa415, 0x4809, 0xa5, 0x5c, 0xb4, 0x99, 0x34, 0xd8, 0x1a, 0xb7);

com::class! {
    pub class MyClass: ComPtr<IFilterMapper2> {
        a: i32,
    }

    impl ComPtr<IFilterMapper2> for MyClass {
        fn EnumMatchingFilters(&self) -> HRESULT { E_NOINTERFACE }
    }
}

com::inproc_dll_module![(CLSID_MY_CLASS, MyClass),];
```