### PR TITLE
Allow win naming conventions in ENUM! and STRUCT!

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -354,31 +354,40 @@ macro_rules! BITFIELD {
         )+}
     }
 }
+
 #[macro_export]
+#[allow(non_snake_case)]
 macro_rules! ENUM {
     {enum $name:ident { $($variant:ident = $value:expr,)+ }} => {
+        #[allow(non_camel_case_types)]
         pub type $name = u32;
-        $(pub const $variant: $name = $value;)+
+        $(#[allow(non_upper_case_globals)] pub const $variant: $name = $value;)+
     };
     {enum $name:ident { $variant:ident = $value:expr, $($rest:tt)* }} => {
+        #[allow(non_camel_case_types)]
         pub type $name = u32;
+        #[allow(non_upper_case_globals)]
         pub const $variant: $name = $value;
         ENUM!{@gen $name $variant, $($rest)*}
     };
     {enum $name:ident { $variant:ident, $($rest:tt)* }} => {
-        ENUM!{enum $name { $variant = 0, $($rest)* }}
+        ENUM!{#[allow(non_camel_case_types)] enum $name { $variant = 0, $($rest)* }}
     };
     {@gen $name:ident $base:ident,} => {};
     {@gen $name:ident $base:ident, $variant:ident = $value:expr, $($rest:tt)*} => {
+        #[allow(non_upper_case_globals)]
         pub const $variant: $name = $value;
         ENUM!{@gen $name $variant, $($rest)*}
     };
     {@gen $name:ident $base:ident, $variant:ident, $($rest:tt)*} => {
+        #[allow(non_upper_case_globals)]
         pub const $variant: $name = $base + 1u32;
         ENUM!{@gen $name $variant, $($rest)*}
     };
 }
+
 #[macro_export]
+#[allow(non_snake_case)]
 macro_rules! STRUCT {
     (#[debug] $($rest:tt)*) => (
         STRUCT!{#[cfg_attr(feature = "impl-debug", derive(Debug))] $($rest)*}
@@ -386,7 +395,7 @@ macro_rules! STRUCT {
     ($(#[$attrs:meta])* struct $name:ident {
         $($field:ident: $ftype:ty,)+
     }) => (
-        #[repr(C)] #[derive(Copy)] $(#[$attrs])*
+        #[repr(C)] #[derive(Copy)] #[allow(non_snake_case)] $(#[$attrs])*
         pub struct $name {
             $(pub $field: $ftype,)+
         }


### PR DESCRIPTION
Currently the ENUM! and STRUCT! macros generate a lot of lint warnings, here's an example taken from some code I am writing:

```rust
winapi::ENUM! {
    enum STORAGE_BUS_TYPE{
      BusTypeUnknown = 0,
      BusTypeScsi = 1,
      BusTypeAtapi = 2,
      BusTypeAta = 3,
      BusType1394 = 4 ,
      BusTypeSsa = 5,
      BusTypeFibre = 6,
      BusTypeUsb = 7,
      BusTypeRAID = 8,
      BusTypeiScsi = 9,
      BusTypeSas = 10,
      BusTypeSata = 11,
      BusTypeSd = 12,
      BusTypeMmc = 13,
      BusTypeVirtual = 14,
      BusTypeFileBackedVirtual = 15,
      BusTypeSpaces = 16,
      BusTypeNvme = 17,
      BusTypeSCM = 18,
      BusTypeUfs = 19,
      BusTypeMax = 20,
      BusTypeMaxReserved = 21,
    }
}

winapi::STRUCT! {
    #[derive(Debug)]
    struct STORAGE_DEVICE_DESCRIPTOR {
        Version: DWORD,
        Size: DWORD,
        DeviceType: BYTE,
        DeviceTypeModifier: BYTE,
        RemovableMedia: BOOLEAN,
        CommandQueueing: BOOLEAN,
        VendorIdOffset: DWORD,
        ProductIdOffset: DWORD,
        ProductRevisionOffset: DWORD,
        SerialNumberOffset: DWORD,
        BusType: STORAGE_BUS_TYPE,
        RawPropertiesLength: DWORD,
        RawDeviceProperties: [BYTE; 1],
    }
}
```

`cargo build` output:

![image](https://user-images.githubusercontent.com/44753941/118804309-c7e5d980-b861-11eb-8fb2-8b8bdd1ceb01.png)


This PR adds `#[allow(non_camel_case_types)]`, `#[allow(non_upper_case_globals)]` and `#[allow(non_snake_case)]` to suppress
`type` `const` and struct field naming conflicts respectively.