### PR TITLE
Use core c_void type and remove need for libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ debug = ["impl-debug"]
 everything = []
 impl-debug = []
 impl-default = []
-std = []
 #km
 d3dkmthk = []
 #mmos

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,6 @@
 //#![cfg_attr(feature = "cargo-clippy", warn(clippy::pedantic))]
 //#![cfg_attr(feature = "cargo-clippy", allow(clippy::absurd_extreme_comparisons, clippy::cast_lossless, clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_precision_loss, clippy::cast_ptr_alignment, clippy::cast_sign_loss, clippy::doc_markdown, clippy::empty_enum, clippy::erasing_op, clippy::excessive_precision, clippy::expl_impl_clone_on_copy, clippy::identity_op, clippy::if_not_else, clippy::many_single_char_names, clippy::module_inception, clippy::cast_possible_truncation, clippy::too_many_arguments, clippy::transmute_int_to_float, clippy::trivially_copy_pass_by_ref, clippy::unreadable_literal, clippy::unseparated_literal_suffix, clippy::used_underscore_binding, clippy::redundant_static_lifetimes, clippy::missing_safety_doc))]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 /// Hack for exported macros
 #[doc(hidden)]
 pub extern crate core as _core;
@@ -32,10 +29,7 @@ pub mod winrt;
 
 /// Built in primitive types provided by the C language
 pub mod ctypes {
-    #[cfg(feature = "std")]
-    pub use std::os::raw::c_void;
-    #[cfg(not(feature = "std"))]
-    pub enum c_void {}
+    pub use _core::ffi::c_void;
     pub type c_char = i8;
     pub type c_schar = i8;
     pub type c_uchar = u8;


### PR DESCRIPTION
It created an issue in [sysinfo](https://github.com/GuillaumeGomez/sysinfo/issues/570).