### PR TITLE
add WDA_EXCLUDEFROMCAPTURE const for WindowsDisplayAffinity api

### DIFF
--- a/src/um/winuser.rs
+++ b/src/um/winuser.rs
@@ -2451,6 +2451,7 @@ extern "system" {
 }
 pub const WDA_NONE: DWORD = 0x00000000;
 pub const WDA_MONITOR: DWORD = 0x00000001;
+pub const WDA_EXCLUDEFROMCAPTURE: DWORD = 0x00000011;
 extern "system" {
     pub fn GetWindowDisplayAffinity(
         hWnd: HWND,


### PR DESCRIPTION
I just add WDA_EXCLUDEFROMCAPTURE  const base on documentation
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity