### PR TITLE
feat(LICENSE): include the license files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/retep998/winapi-rs"
 readme = "README.md"
 keywords = ["windows", "ffi", "win32", "com", "directx"]
 categories = ["external-ffi-bindings", "no-std", "os::windows-apis"]
-include = ["/src/**/*", "/Cargo.toml", "/LICENSE-MIT", "/LICENSE-APACHE", "/build.rs", "/README.md"]
+include = ["src/**/*", "Cargo.toml", "LICENSE-*", "build.rs", "README.md"]
 build = "build.rs"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
this small change makes sure the LICENSE files are included in the crate artefact. 

Right now they are missing. I suspect the leading `/` is not correct.