### PR TITLE
v0.2 branch: derive Copy instead of implementing it by hand

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -252,19 +252,17 @@ macro_rules! FLAGS {
 }
 macro_rules! STRUCT {
     {$(#[$attrs:meta])* nodebug struct $name:ident { $($field:ident: $ftype:ty,)+ }} => {
-        #[repr(C)] $(#[$attrs])*
+        #[repr(C)] #[derive(Copy)] $(#[$attrs])*
         pub struct $name {
             $(pub $field: $ftype,)+
         }
-        impl Copy for $name {}
         impl Clone for $name { fn clone(&self) -> $name { *self } }
     };
     {$(#[$attrs:meta])* struct $name:ident { $($field:ident: $ftype:ty,)+ }} => {
-        #[repr(C)] #[derive(Debug)] $(#[$attrs])*
+        #[repr(C)] #[derive(Debug, Copy)] $(#[$attrs])*
         pub struct $name {
             $(pub $field: $ftype,)+
         }
-        impl Copy for $name {}
         impl Clone for $name { fn clone(&self) -> $name { *self } }
     };
 }


### PR DESCRIPTION
Fixes https://github.com/retep998/winapi-rs/issues/1030

Turns out hyper 0.12 transitively depends via tokio 0.1 on winapi 0.2. Would be good to get a semver-compatible update out so that these crates can be kept working.